### PR TITLE
docs: restrict pull request labels to ownership only (filigran team / community) (#128)

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -67,15 +67,15 @@ are valid types; they do not each require a dedicated label (use a repository
 area/scope label where useful). `security` is a **label** (applied on top of the
 type, e.g. a `fix:` that closes a vulnerability), not a title type.
 
-> **Pull requests do NOT carry a primary type label.** A pull request's `type:`
-> title prefix (and its linked issue) already convey the type, so `feature`,
-> `bug` and `documentation` must **never** be added to a pull request — remove
-> them if they appear.
+> **Pull request labels are restricted to ownership only.** A pull request
+> carries exactly **one ownership label — `filigran team` or `community` — and
+> nothing else.** Every other label (primary type labels, area/scope labels,
+> workflow/triage labels) is **issue-only** and must **never** be added to a pull
+> request; remove any that appear. The PR's `type:` title prefix and its linked
+> issue already convey the type and the affected area.
 >
-> Pull requests **do** still carry other labels. In particular, add an
-> **ownership** label — typically `filigran team` or `community` — so the source
-> of a contribution is clear at a glance. Area/scope labels and workflow labels
-> (e.g. `dependencies`, `do not merge`) also apply to pull requests where useful.
+> *Exception:* dependency-automation labels (e.g. `dependencies`) are applied by
+> Renovate/Dependabot to their own pull requests, which are exempt.
 
 ## 3. Workflow & ownership labels
 
@@ -96,7 +96,9 @@ See [`.github/labels.yml`](labels.yml) for the exact colors and descriptions.
 On top of the shared labels above, repositories define their own area/scope
 labels (e.g. `frontend`, `backend`, `connector: <name>`, `collector: <name>`,
 `agents`, `authentication`). They add routing context and an issue may carry
-more than one. They are not listed in `labels.yml`.
+more than one. They are **issue-only** — like type and workflow labels, they are
+**not** added to pull requests (a PR carries only its `filigran team` /
+`community` ownership label). They are not listed in `labels.yml`.
 
 All label names are **lowercase**. Repository-specific labels use a neutral grey
 color (`ededed`); only the shared labels above carry color, so the common
@@ -115,9 +117,9 @@ taxonomy stands out consistently across every Filigran repository.
 - [ ] **Issues only:** exactly one primary type label (`feature` / `bug` /
       `documentation`) matches the title prefix, and the GitHub **Type** field
       (Feature / Bug / Task) is set to match
-- [ ] **Pull requests:** no primary type label (the title prefix conveys the
-      type); add an ownership label (`filigran team` / `community`) and any useful
-      area labels
-- [ ] Area labels added where useful
+- [ ] **Pull requests:** exactly one ownership label — `filigran team` or
+      `community` — and **no other label** (type, area/scope and workflow labels
+      are issue-only)
+- [ ] Issues: area labels added where useful
 - [ ] No deprecated labels
 - [ ] Commits are signed and the PR is linked to an issue

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -78,10 +78,10 @@
 # ── Ownership / community labels ──
 - name: filigran team
   color: "4a0c43"
-  description: "Item from the Filigran team."
+  description: "Ownership: from the Filigran team. The PR ownership label for Filigran-authored pull requests."
 - name: community
   color: "268e45"
-  description: "Contribution from the community."
+  description: "Ownership: from the community. The PR ownership label for community-authored pull requests."
 - name: community support
   color: "ffa500"
   description: "Feature developed and maintained by the community."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -199,11 +199,10 @@ in [`.github/LABELS.md`](.github/LABELS.md). In short:
 * **Labels** — Every **issue** carries one primary type label matching its title
   prefix (`feature` for `feat:`, `bug` for `fix:`, `documentation` for `docs:`)
   plus optional area labels, and its GitHub **Type** (Feature / Bug / Task) set
-  to match. **Pull requests do not carry a primary type label** (the `type:`
-  title prefix already conveys the type), but they should carry an **ownership**
-  label — `filigran team` or `community` — to differentiate the author, plus any
-  useful area/scope labels. Do not use the deprecated `enhancement` /
-  `feature request` labels — use `feature`. See
-  [`.github/LABELS.md`](.github/LABELS.md) for the shared palette
-  ([`.github/labels.yml`](.github/labels.yml)).
+  to match. **Pull requests are labelled with ownership only** — exactly one of
+  `filigran team` or `community`, and **nothing else**: type, area/scope and
+  workflow labels are issue-only (Renovate/Dependabot dependency labels are
+  exempt). Do not use the deprecated `enhancement` / `feature request` labels —
+  use `feature`. See [`.github/LABELS.md`](.github/LABELS.md) for the shared
+  palette ([`.github/labels.yml`](.github/labels.yml)).
 <!-- filigran-conventions:end -->


### PR DESCRIPTION
## Summary

Makes the shared label rule unambiguous so it can never be misread (by a human or an automated reviewer):

- A **pull request carries exactly one ownership label — `filigran team` or `community` — and nothing else.**
- **Primary type labels** (`feature` / `bug` / `documentation`), **area/scope labels**, and **workflow/triage labels** are **issue-only** and must never be added to a PR.
- *Exception:* dependency-automation labels (`dependencies`) on Renovate/Dependabot PRs are exempt.

Updated `.github/LABELS.md`, `.github/labels.yml`, and the CONTRIBUTING conventions block.

Closes #128