### PR TITLE
fix(setup): add settings-page fallback and make tab injection fire-and-forget (#136)

### DIFF
--- a/src/popup/hooks/usePopupActions.ts
+++ b/src/popup/hooks/usePopupActions.ts
@@ -272,10 +272,34 @@ export const usePopupActions = ({
     }
   }, [ensureContentScriptAndSendMessage, isPdfScannerPage]);
 
-  const handleOpenSettings = useCallback(() => {
-    if (typeof chrome === 'undefined' || !chrome.runtime?.openOptionsPage) return;
-    chrome.runtime.openOptionsPage();
+  const openSettingsPage = useCallback(async () => {
+    if (typeof chrome === 'undefined' || !chrome.runtime) return;
+
+    const optionsUrl = chrome.runtime.getURL('options/index.html');
+
+    try {
+      if (chrome.runtime.openOptionsPage) {
+        await chrome.runtime.openOptionsPage();
+        return;
+      }
+    } catch (error) {
+      log.warn('openOptionsPage failed, falling back to direct options URL:', error);
+    }
+
+    try {
+      if (chrome.tabs?.create) {
+        await chrome.tabs.create({ url: optionsUrl });
+      } else {
+        window.open(optionsUrl, '_blank');
+      }
+    } catch (error) {
+      log.error('Failed to open settings page:', error);
+    }
   }, []);
+
+  const handleOpenSettings = useCallback(() => {
+    void openSettingsPage();
+  }, [openSettingsPage]);
 
   const handleOpenPlatform = useCallback((url: string) => {
     if (typeof chrome === 'undefined' || !chrome.tabs) return;
@@ -295,15 +319,13 @@ export const usePopupActions = ({
     }
     
     if (hasEnterprise) {
-      if (typeof chrome !== 'undefined' && chrome.runtime?.openOptionsPage) {
-        chrome.runtime.openOptionsPage();
-      }
+      await openSettingsPage();
       window.close();
       return;
     }
     
     setShowEETrialDialog(true);
-  }, [aiConfigured, hasEnterprise, setShowEETrialDialog]);
+  }, [aiConfigured, hasEnterprise, openSettingsPage, setShowEETrialDialog]);
 
   return {
     ensureContentScriptAndSendMessage,
@@ -322,4 +344,3 @@ export const usePopupActions = ({
 };
 
 export default usePopupActions;
-

--- a/src/popup/hooks/useSetupWizard.ts
+++ b/src/popup/hooks/useSetupWizard.ts
@@ -272,18 +272,17 @@ export const useSetupWizard = ({ setStatus }: UseSetupWizardProps): UseSetupWiza
       log.debug(`Settings saved successfully for ${platformType}, isEnterprise: ${isEnterprise}`);
       
       setSetupSuccess(true);
-      
-      // Inject content scripts into all open tabs
-      try {
-        await chrome.runtime.sendMessage({ type: 'INJECT_ALL_TABS' });
-      } catch (error) {
+      setSetupTesting(false);
+
+      // Inject content scripts into all open tabs without blocking setup flow.
+      // Some environments/tabs may keep this message pending for too long.
+      void chrome.runtime.sendMessage({ type: 'INJECT_ALL_TABS' }).catch((error) => {
         log.debug('Note: Could not inject content scripts into existing tabs:', error);
-      }
+      });
       
       // Move to next step after a short delay
-      setTimeout(async () => {
+      setTimeout(() => {
         resetSetupForm();
-        setSetupTesting(false);
         
         if (platformType === 'opencti') {
           setSetupStepInternal('openaev');
@@ -327,4 +326,3 @@ export const useSetupWizard = ({ setStatus }: UseSetupWizardProps): UseSetupWiza
 };
 
 export default useSetupWizard;
-


### PR DESCRIPTION
Add a safe settings-page fallback when `openOptionsPage` is unavailable or fails. Make `INJECT_ALL_TABS` fire-and-forget in setup so the wizard does not block on slow tab injection responses.
 
 ### Proposed changes
 
 - Add a safe fallback to open the settings page when `openOptionsPage` is missing or throws.
 - Change setup flow to trigger `INJECT_ALL_TABS` without awaiting slow tab injection responses.
 
 ### Related issues
 
 ### How to test this PR
 
 1. Run extension setup in a browser where `openOptionsPage` is unavailable/fails and confirm settings still open through fallback.
 2. Start setup with many tabs/open slow pages and confirm wizard continues immediately.
 3. Verify tab injection still happens in background and features behave as expected afterward.
 
 ### Checklist
 
 - [ ] The PR title follows the Conventional Commits convention `type(scope?): description (#issue)`
 - [ ] I signed my commits
 - [ ] This PR is linked to an issue
 - [x] I consider the submitted work as finished
 - [x] I tested the code for its functionality
 - [ ] I added/updated the relevant documentation
 - [x] Where necessary, I refactored code to improve the overall quality