### PR TITLE
fix(ci): fix Playwright browser install hanging during extraction (#135)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -734,13 +734,26 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Install Playwright browsers and xvfb
+      - name: Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('**/package-lock.json') }}
+
+      - name: Install Playwright browser and system dependencies
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
+
+      - name: Install Playwright system dependencies (cache hit)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+
+      - name: Install xvfb
         run: |
-          # Install xvfb for virtual display (required for headed Chrome with extensions)
-          sudo apt-get update
-          sudo apt-get install -y xvfb
-          # Install Playwright with Chromium and dependencies
-          npx playwright install chromium --with-deps
+          echo "Installing xvfb for headed Chrome..."
+          sudo apt-get update && sudo apt-get install -y xvfb
+          echo "xvfb install complete."
 
       - name: Build extension with coverage instrumentation
         run: npm run build:coverage

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@istanbuljs/nyc-config-typescript": "^1.0.2",
-        "@playwright/test": "^1.57.0",
+        "@playwright/test": "^1.61.0",
         "@types/chrome": "^0.1.32",
         "@types/mozilla-readability": "^0.2.1",
         "@types/node": "^25.0.3",
@@ -44,7 +44,7 @@
         "globals": "^17.0.0",
         "jsdom": "^28.0.0",
         "nyc": "^18.0.0",
-        "playwright": "^1.57.0",
+        "playwright": "^1.61.0",
         "serve": "^14.2.4",
         "sharp": "^0.34.5",
         "terser": "^5.44.1",
@@ -2769,13 +2769,13 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.0.tgz",
+      "integrity": "sha512-cKA5B6lpFEMyMGjxF54QihfYpB4FkEGH+qZhtArDEG+wezQAJY8Pq6C7T1SjWz+FFzt3TbyoXBQYk/0292TdJA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright": "1.58.2"
+        "playwright": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9578,13 +9578,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.0.tgz",
+      "integrity": "sha512-Z+7BeeqQPRRzklHsVFP4KTGIyMxKUmfeRA4WisM6G3/XW6nwGeX6fX9qYaDa+CiUqpOkb2f6X3nar05R3kSuJQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.61.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -9597,9 +9597,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.61.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.0.tgz",
+      "integrity": "sha512-caX7TrY3Ml6egyDX0WUcTHDxodl/b51y5wJOdCEA36QviK/s2g081hvmGs8eaE3DWb6NYZQ6BjO/QkNRPenoPA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@istanbuljs/nyc-config-typescript": "^1.0.2",
-    "@playwright/test": "^1.57.0",
+    "@playwright/test": "^1.61.0",
     "@types/chrome": "^0.1.32",
     "@types/mozilla-readability": "^0.2.1",
     "@types/node": "^25.0.3",
@@ -68,7 +68,7 @@
     "globals": "^17.0.0",
     "jsdom": "^28.0.0",
     "nyc": "^18.0.0",
-    "playwright": "^1.57.0",
+    "playwright": "^1.61.0",
     "serve": "^14.2.4",
     "sharp": "^0.34.5",
     "terser": "^5.44.1",


### PR DESCRIPTION
Upgrade Playwright from 1.58.2 to 1.61.0 to work around a Node.js 24.16.0 bug (nodejs/node#63487) that causes extract-zip to hang indefinitely during browser binary extraction.
    
Also align the install steps with other filigran repositories pattern: use --with-deps on cache miss and guard install-deps to cache hit only.
    
  Refs:
  - https://github.com/nodejs/node/issues/63487
  - https://github.com/microsoft/playwright/issues/41000