### PR TITLE
fix(ci): dependabot PRs fail PR title validation (#137)

### DIFF
--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -11,7 +11,7 @@ jobs:
   validate-pr-title:
     name: Validate Conventional PR title
     runs-on: ubuntu-latest
-    if: github.event.pull_request.user.login != 'renovate[bot]' && !startsWith(github.event.pull_request.title, '[Snyk]')
+    if: github.event.pull_request.user.login != 'renovate[bot]' && github.event.pull_request.user.login != 'dependabot[bot]' && !startsWith(github.event.pull_request.title, '[Snyk]')
     steps:
       - name: Check Conventional Commit title
         env:


### PR DESCRIPTION
Dependabot PRs fail the "Validate Conventional PR title" workflow because their titles don't include an issue reference (`(#123)`).
 
The workflow already skips `renovate[bot]` and Snyk PRs but not `dependabot[bot]`