### PR TITLE
fix(pdf): support CJK characters in PDF snapshots (#103)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ttf filter=lfs diff=lfs merge=lfs -text

--- a/src/assets/fonts/NotoSansCJK-Regular.ttf
+++ b/src/assets/fonts/NotoSansCJK-Regular.ttf
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:426e4c95cbfc619e4e6c01c7a2cee16254a95e4fcaebd742afdf5f3c0c9398fb
+size 19934892

--- a/src/content/extraction.ts
+++ b/src/content/extraction.ts
@@ -8,7 +8,8 @@ import {
   extractContent, 
   type ExtractedContent 
 } from '../shared/extraction/content-extractor';
-import { generatePDF } from '../shared/extraction/pdf-generator';
+import { generatePDF, sanitizeFilename } from '../shared/extraction/pdf-generator';
+import { registerCJKFont, needsCJKFont, CJK_FONT_FAMILY } from '../shared/extraction/cjk-font';
 import { jsPDF } from 'jspdf';
 
 const log = loggers.content;
@@ -935,6 +936,17 @@ async function generateFallbackPDF(article: { title: string; content: string; te
       unit: 'mm',
       format: 'a4',
     });
+
+    let fontFamily = 'helvetica';
+    if (needsCJKFont((article.title || '') + (article.textContent || '') + (article.content || ''))) {
+      const hasCJK = await registerCJKFont(pdf);
+      if (hasCJK) fontFamily = CJK_FONT_FAMILY;
+    }
+
+    const isCJK = fontFamily === CJK_FONT_FAMILY;
+    const setFont = (style: string) => {
+      pdf.setFont(fontFamily, isCJK ? 'normal' : style);
+    };
     
     const pageWidth = pdf.internal.pageSize.getWidth();
     const pageHeight = pdf.internal.pageSize.getHeight();
@@ -976,7 +988,7 @@ async function generateFallbackPDF(article: { title: string; content: string; te
         if (alt && alt.length > 5) {
           pdf.setFontSize(9);
           pdf.setTextColor(100, 100, 100);
-          pdf.setFont('helvetica', 'italic');
+          setFont('italic');
           const captionLines = pdf.splitTextToSize(alt, contentWidth);
           pdf.text(captionLines, margin, yPosition);
           yPosition += captionLines.length * 4 + 2;
@@ -993,20 +1005,20 @@ async function generateFallbackPDF(article: { title: string; content: string; te
     
     pdf.setFontSize(10);
     pdf.setTextColor(0, 27, 218);
-    pdf.setFont('helvetica', 'bold');
+    setFont('bold');
     pdf.text('Filigran XTM Browser Extension', margin, yPosition);
     yPosition += 5;
     
     pdf.setFontSize(9);
     pdf.setTextColor(100, 100, 100);
-    pdf.setFont('helvetica', 'normal');
+    setFont('normal');
     pdf.text(`Captured on ${new Date().toLocaleDateString()}`, margin, yPosition);
     yPosition += 10;
     
     // Title
     pdf.setFontSize(18);
     pdf.setTextColor(0, 0, 0);
-    pdf.setFont('helvetica', 'bold');
+    setFont('bold');
     const titleLines = pdf.splitTextToSize(article.title, contentWidth);
     checkPageBreak(titleLines.length * 7);
     pdf.text(titleLines, margin, yPosition);
@@ -1015,7 +1027,7 @@ async function generateFallbackPDF(article: { title: string; content: string; te
     // Source URL
     pdf.setFontSize(9);
     pdf.setTextColor(0, 100, 200);
-    pdf.setFont('helvetica', 'normal');
+    setFont('normal');
     const truncatedUrl = window.location.href.length > 80 
       ? window.location.href.substring(0, 77) + '...' 
       : window.location.href;
@@ -1046,7 +1058,7 @@ async function generateFallbackPDF(article: { title: string; content: string; te
           else if (isBold) fontStyle = 'bold';
           else if (isItalic) fontStyle = 'italic';
           
-          pdf.setFont('helvetica', fontStyle);
+          setFont(fontStyle);
           pdf.setFontSize(fontSize);
           pdf.setTextColor(30, 30, 30);
           
@@ -1106,7 +1118,7 @@ async function generateFallbackPDF(article: { title: string; content: string; te
               const li = listItems[idx];
               checkPageBreak(lineHeight);
               const bullet = tagName === 'ul' ? '•' : `${idx + 1}.`;
-              pdf.setFont('helvetica', 'normal');
+              setFont('normal');
               pdf.setFontSize(11);
               pdf.setTextColor(30, 30, 30);
               pdf.text(bullet, margin, yPosition);
@@ -1133,7 +1145,7 @@ async function generateFallbackPDF(article: { title: string; content: string; te
             const linkText = el.textContent?.trim() || '';
             if (linkText && href) {
               pdf.setTextColor(0, 100, 200);
-              pdf.setFont('helvetica', isBold ? 'bold' : 'normal');
+              setFont(isBold ? 'bold' : 'normal');
               pdf.setFontSize(fontSize);
               const lines = pdf.splitTextToSize(linkText, contentWidth);
               checkPageBreak(lines.length * lineHeight);
@@ -1154,7 +1166,7 @@ async function generateFallbackPDF(article: { title: string; content: string; te
             if (figCaption) {
               pdf.setFontSize(9);
               pdf.setTextColor(100, 100, 100);
-              pdf.setFont('helvetica', 'italic');
+              setFont('italic');
               const captionText = figCaption.textContent?.trim() || '';
               const captionLines = pdf.splitTextToSize(captionText, contentWidth);
               checkPageBreak(captionLines.length * 4);
@@ -1165,14 +1177,14 @@ async function generateFallbackPDF(article: { title: string; content: string; te
           case 'pre':
           case 'code':
             checkPageBreak(lineHeight);
-            pdf.setFont('courier', 'normal');
+            pdf.setFont(isCJK ? fontFamily : 'courier', 'normal');
             pdf.setFontSize(9);
             pdf.setTextColor(50, 50, 50);
             const codeText = el.textContent?.trim() || '';
             const codeLines = pdf.splitTextToSize(codeText, contentWidth);
             pdf.text(codeLines, margin, yPosition);
             yPosition += codeLines.length * 4 + 2;
-            pdf.setFont('helvetica', 'normal');
+            setFont('normal');
             break;
           case 'hr':
             checkPageBreak(6);
@@ -1252,7 +1264,18 @@ async function generateSimpleTextPDF(): Promise<{ data: string; filename: string
       unit: 'mm',
       format: 'a4',
     });
-    
+
+    let fontFamily = 'helvetica';
+    if (needsCJKFont(article.title + textContent)) {
+      const hasCJK = await registerCJKFont(pdf);
+      if (hasCJK) fontFamily = CJK_FONT_FAMILY;
+    }
+
+    const isCJK = fontFamily === CJK_FONT_FAMILY;
+    const setFont = (style: string) => {
+      pdf.setFont(fontFamily, isCJK ? 'normal' : style);
+    };
+
     const pageWidth = pdf.internal.pageSize.getWidth();
     const pageHeight = pdf.internal.pageSize.getHeight();
     const margin = 20;
@@ -1266,17 +1289,20 @@ async function generateSimpleTextPDF(): Promise<{ data: string; filename: string
     
     pdf.setFontSize(10);
     pdf.setTextColor(0, 27, 218);
+    setFont('bold');
     pdf.text('XTM Browser Extension', margin, yPosition);
     yPosition += 5;
     
     pdf.setFontSize(9);
     pdf.setTextColor(100, 100, 100);
+    setFont('normal');
     pdf.text(`Captured on ${new Date().toLocaleDateString()}`, margin, yPosition);
     yPosition += 10;
     
     // Title
     pdf.setFontSize(16);
     pdf.setTextColor(0, 0, 0);
+    setFont('bold');
     const titleLines = pdf.splitTextToSize(article.title, contentWidth);
     pdf.text(titleLines, margin, yPosition);
     yPosition += (titleLines.length * 7) + 5;
@@ -1284,6 +1310,7 @@ async function generateSimpleTextPDF(): Promise<{ data: string; filename: string
     // Source
     pdf.setFontSize(9);
     pdf.setTextColor(100, 100, 100);
+    setFont('normal');
     const sourceUrl = window.location.href;
     const truncatedUrl = sourceUrl.length > 80 ? sourceUrl.substring(0, 77) + '...' : sourceUrl;
     pdf.text(`Source: ${truncatedUrl}`, margin, yPosition);
@@ -1298,6 +1325,7 @@ async function generateSimpleTextPDF(): Promise<{ data: string; filename: string
     // Content
     pdf.setFontSize(11);
     pdf.setTextColor(30, 30, 30);
+    setFont('normal');
     
     const paragraphs = textContent.split(/\n\n+/).filter(p => p.trim().length > 0);
     
@@ -1338,13 +1366,4 @@ async function generateSimpleTextPDF(): Promise<{ data: string; filename: string
   }
 }
 
-/**
- * Sanitize filename for PDF
- */
-export function sanitizeFilename(name: string): string {
-  return name
-    .replace(/[<>:"/\\|?*]/g, '')
-    .replace(/\s+/g, '_')
-    .substring(0, 100);
-}
 

--- a/src/shared/extraction/cjk-font.ts
+++ b/src/shared/extraction/cjk-font.ts
@@ -1,0 +1,111 @@
+/**
+ * CJK Font loader for jsPDF
+ *
+ * Loads the bundled Noto Sans CJK font on demand and registers it with jsPDF
+ * so that CJK characters (Japanese, Chinese, Korean) render correctly.
+ * The font is only loaded when CJK characters are detected in the content.
+ */
+
+import { jsPDF } from 'jspdf';
+import { loggers } from '../utils/logger';
+
+const log = loggers.extraction;
+
+const CJK_FONT_FILENAME = 'NotoSansCJK-Regular.ttf';
+const CJK_FONT_FAMILY = 'NotoSansCJK';
+
+// BMP ranges: CJK Symbols/Punctuation, Hiragana, Katakana, Bopomofo,
+// CJK Extension A, CJK Unified Ideographs, Hangul Syllables/Jamo,
+// CJK Compatibility Ideographs.
+// Supplementary: CJK Extension B–F, CJK Compatibility Supplement.
+const CJK_RE = /[\u3000-\u303F\u3040-\u309F\u30A0-\u30FF\u3100-\u312F\u3400-\u4DBF\u4E00-\u9FFF\uAC00-\uD7AF\uF900-\uFAFF\u1100-\u11FF\u{20000}-\u{2FA1F}]/u;
+
+/**
+ * Check whether text contains CJK characters that require
+ * the bundled font to render.
+ */
+export function needsCJKFont(text: string): boolean {
+  return CJK_RE.test(text);
+}
+
+// Promise-based lock: held only while a fetch is in progress.
+// Resets after resolve so the base64 string can be GC'd between PDF generations.
+let fontLoadPromise: Promise<string | null> | null = null;
+
+/**
+ * Load the CJK font file from extension assets and return as base64.
+ * Uses a promise lock to prevent duplicate concurrent fetches.
+ * The result is NOT cached long-term to avoid holding ~25 MB in memory.
+ */
+function loadCJKFontBase64(): Promise<string | null> {
+  if (fontLoadPromise) return fontLoadPromise;
+
+  fontLoadPromise = (async () => {
+    try {
+      const fontUrl = chrome.runtime.getURL(`assets/fonts/${CJK_FONT_FILENAME}`);
+      const response = await fetch(fontUrl);
+      if (!response.ok) {
+        log.warn('[CJKFont] Failed to fetch font:', response.status);
+        return null;
+      }
+
+      const buffer = await response.arrayBuffer();
+      const bytes = new Uint8Array(buffer);
+
+      // Chunk-based binary→string conversion.
+      // Uses a pre-allocated array + join instead of spread to avoid
+      // hitting engine-specific call-stack argument limits.
+      const chunkSize = 8192;
+      const chunks: string[] = [];
+      for (let i = 0; i < bytes.length; i += chunkSize) {
+        const end = Math.min(i + chunkSize, bytes.length);
+        const charCodes = new Array<string>(end - i);
+        for (let j = i; j < end; j++) {
+          charCodes[j - i] = String.fromCharCode(bytes[j]);
+        }
+        chunks.push(charCodes.join(''));
+      }
+      const base64 = btoa(chunks.join(''));
+
+      log.debug('[CJKFont] Font loaded, size:', bytes.length);
+      return base64;
+    } catch (error) {
+      log.warn('[CJKFont] Error loading font:', error);
+      return null;
+    }
+  })().finally(() => {
+    // Release the lock so the resolved base64 string can be GC'd
+    // once registerCJKFont is done with it.
+    fontLoadPromise = null;
+  });
+
+  return fontLoadPromise;
+}
+
+/**
+ * Register the CJK font with a jsPDF instance.
+ * Loads the font, validates it, and registers for the 'normal' style.
+ * Bold/italic calls will fall back to normal automatically in jsPDF.
+ */
+export async function registerCJKFont(pdf: jsPDF): Promise<boolean> {
+  try {
+    const fontBase64 = await loadCJKFontBase64();
+    if (!fontBase64) return false;
+
+    pdf.addFileToVFS(CJK_FONT_FILENAME, fontBase64);
+    pdf.addFont(CJK_FONT_FILENAME, CJK_FONT_FAMILY, 'normal');
+
+    // Verify the font is usable by attempting to set it
+    pdf.setFont(CJK_FONT_FAMILY, 'normal');
+
+    return true;
+  } catch (error) {
+    log.warn('[CJKFont] Failed to register font (file may be corrupt):', error);
+    return false;
+  }
+}
+
+/**
+ * The font family name to use after registration.
+ */
+export { CJK_FONT_FAMILY };

--- a/src/shared/extraction/pdf-generator.ts
+++ b/src/shared/extraction/pdf-generator.ts
@@ -1,13 +1,13 @@
 /**
  * Enhanced PDF Generator
  * 
- * Generates high-quality PDFs using:
- * 1. Chrome's native print-to-PDF (via Debugger API) - Best quality
- * 2. Reader-view rendering with jsPDF - Fallback with selectable text
+ * Generates high-quality PDFs using jsPDF with CJK font support
+ * for proper Unicode/CJK character rendering across all browsers.
  */
 
 import { jsPDF } from 'jspdf';
 import type { ExtractedContent, ExtractedImage } from './content-extractor';
+import { registerCJKFont, needsCJKFont, CJK_FONT_FAMILY } from './cjk-font';
 import { loggers } from '../utils/logger';
 
 const log = loggers.extraction;
@@ -15,7 +15,7 @@ const log = loggers.extraction;
 export interface PDFGenerationResult {
   data: string; // Base64 encoded PDF
   filename: string;
-  method: 'native' | 'jspdf' | 'canvas';
+  method: 'jspdf';
 }
 
 export interface PDFOptions {
@@ -47,8 +47,7 @@ const PAPER_SIZES = {
 };
 
 /**
- * Generate PDF from extracted content
- * Tries native print first, falls back to jsPDF
+ * Generate PDF from extracted content using jsPDF
  */
 export async function generatePDF(
   content: ExtractedContent,
@@ -56,34 +55,13 @@ export async function generatePDF(
 ): Promise<PDFGenerationResult | null> {
   const opts = { ...DEFAULT_OPTIONS, ...options };
   
-  // Try jsPDF generation (most reliable for extensions)
   const jspdfResult = await generateWithJsPDF(content, opts);
   if (jspdfResult) {
     return jspdfResult;
   }
   
-  log.error('[PDFGenerator] All PDF generation methods failed');
+  log.error('[PDFGenerator] PDF generation failed');
   return null;
-}
-
-/**
- * Request native PDF generation from background script
- * This uses Chrome's Debugger API for best quality
- */
-export async function requestNativePDF(tabId: number): Promise<string | null> {
-  return new Promise((resolve) => {
-    chrome.runtime.sendMessage(
-      { type: 'GENERATE_NATIVE_PDF', tabId },
-      (response) => {
-        if (response?.success && response.data) {
-          resolve(response.data);
-        } else {
-          log.debug('[PDFGenerator] Native PDF generation failed:', response?.error);
-          resolve(null);
-        }
-      }
-    );
-  });
 }
 
 /**
@@ -101,6 +79,19 @@ async function generateWithJsPDF(
       unit: 'mm',
       format: [paperSize.width, paperSize.height],
     });
+
+    // Only load the CJK font if the content contains non-Latin characters
+    let fontFamily = 'helvetica';
+    if (needsCJKFont((content.title || '') + (content.textContent || '') + (content.content || ''))) {
+      const hasCJK = await registerCJKFont(pdf);
+      if (hasCJK) fontFamily = CJK_FONT_FAMILY;
+    }
+
+    // CJK font only has 'normal' style — ignore bold/italic requests for it
+    const isCJK = fontFamily === CJK_FONT_FAMILY;
+    const setFont = (style: string) => {
+      pdf.setFont(fontFamily, isCJK ? 'normal' : style);
+    };
     
     const pageWidth = pdf.internal.pageSize.getWidth();
     const pageHeight = pdf.internal.pageSize.getHeight();
@@ -123,7 +114,7 @@ async function generateWithJsPDF(
       if (options.headerText) {
         pdf.setFontSize(8);
         pdf.setTextColor(150, 150, 150);
-        pdf.setFont('helvetica', 'normal');
+        setFont('normal');
         pdf.text(options.headerText, margin, 10);
         pdf.setDrawColor(230, 230, 230);
         pdf.line(margin, 12, pageWidth - margin, 12);
@@ -135,7 +126,7 @@ async function generateWithJsPDF(
       const footerY = pageHeight - 8;
       pdf.setFontSize(8);
       pdf.setTextColor(150, 150, 150);
-      pdf.setFont('helvetica', 'normal');
+      setFont('normal');
       
       const pageNum = pdf.getNumberOfPages();
       pdf.text(`Page ${pageNum}`, pageWidth - margin - 15, footerY);
@@ -143,7 +134,10 @@ async function generateWithJsPDF(
       pdf.setDrawColor(230, 230, 230);
       pdf.line(margin, footerY - 3, pageWidth - margin, footerY - 3);
       
-      const hostname = new URL(content.url).hostname;
+      const hostname = (() => {
+        try { return new URL(content.url).hostname; }
+        catch { return content.url; }
+      })();
       pdf.text(hostname, margin, footerY);
     };
     
@@ -235,7 +229,7 @@ async function generateWithJsPDF(
         if (img.caption || img.alt) {
           pdf.setFontSize(9);
           pdf.setTextColor(100, 100, 100);
-          pdf.setFont('helvetica', 'italic');
+          setFont('italic');
           const caption = img.caption || img.alt;
           const captionLines = pdf.splitTextToSize(caption, contentWidth);
           pdf.text(captionLines, margin, yPosition);
@@ -248,12 +242,19 @@ async function generateWithJsPDF(
       }
     };
     
-    // Helper: Get image dimensions from data URL
+    // NOTE: Requires DOM (Image constructor). Only call from content script context.
     const getImageDimensions = (dataUrl: string): Promise<{width: number; height: number} | null> => {
       return new Promise((resolve) => {
+        const timeout = setTimeout(() => resolve(null), 5000);
         const img = new Image();
-        img.onload = () => resolve({ width: img.naturalWidth, height: img.naturalHeight });
-        img.onerror = () => resolve(null);
+        img.onload = () => {
+          clearTimeout(timeout);
+          resolve({ width: img.naturalWidth, height: img.naturalHeight });
+        };
+        img.onerror = () => {
+          clearTimeout(timeout);
+          resolve(null);
+        };
         img.src = dataUrl;
       });
     };
@@ -269,20 +270,20 @@ async function generateWithJsPDF(
     
     pdf.setFontSize(10);
     pdf.setTextColor(0, 27, 218);
-    pdf.setFont('helvetica', 'bold');
+    setFont('bold');
     pdf.text('Filigran XTM Browser Extension', margin, yPosition);
     yPosition += 5;
     
     pdf.setFontSize(9);
     pdf.setTextColor(100, 100, 100);
-    pdf.setFont('helvetica', 'normal');
+    setFont('normal');
     pdf.text(`Captured on ${new Date().toLocaleDateString()}`, margin, yPosition);
     yPosition += 8;
     
     // === Article title ===
     pdf.setFontSize(20);
     pdf.setTextColor(0, 0, 0);
-    pdf.setFont('helvetica', 'bold');
+    setFont('bold');
     const titleLines = pdf.splitTextToSize(content.title, contentWidth);
     checkPageBreak(titleLines.length * 8);
     pdf.text(titleLines, margin, yPosition);
@@ -292,7 +293,7 @@ async function generateWithJsPDF(
     if (content.byline) {
       pdf.setFontSize(10);
       pdf.setTextColor(80, 80, 80);
-      pdf.setFont('helvetica', 'italic');
+      setFont('italic');
       pdf.text(content.byline, margin, yPosition);
       yPosition += 5;
     }
@@ -300,7 +301,7 @@ async function generateWithJsPDF(
     // === Metadata ===
     pdf.setFontSize(9);
     pdf.setTextColor(100, 100, 100);
-    pdf.setFont('helvetica', 'normal');
+    setFont('normal');
     
     const metaParts = [content.siteName];
     if (content.publishedDate) metaParts.push(content.publishedDate);
@@ -325,6 +326,9 @@ async function generateWithJsPDF(
     // Parse the HTML content and render it
     const tempDiv = document.createElement('div');
     tempDiv.innerHTML = content.content;
+    
+    // Remove potentially dangerous or irrelevant elements
+    tempDiv.querySelectorAll('script, style, iframe, noscript').forEach(el => el.remove());
     
     // Track all added image sources to avoid duplicates
     const addedImageSrcs = new Set<string>();
@@ -353,7 +357,7 @@ async function generateWithJsPDF(
           
           pdf.setFontSize(fontSize);
           pdf.setTextColor(0, 0, 0);
-          pdf.setFont('helvetica', 'bold');
+          setFont('bold');
           const lines = pdf.splitTextToSize(text, contentWidth);
           pdf.text(lines, margin, yPosition);
           yPosition += lines.length * (fontSize * 0.4) + 3;
@@ -368,7 +372,7 @@ async function generateWithJsPDF(
           
           pdf.setFontSize(11);
           pdf.setTextColor(30, 30, 30);
-          pdf.setFont('helvetica', 'normal');
+          setFont('normal');
           const lines = pdf.splitTextToSize(text, contentWidth);
           pdf.text(lines, margin, yPosition);
           yPosition += lines.length * 5 + 4;
@@ -388,7 +392,7 @@ async function generateWithJsPDF(
           
           pdf.setFontSize(11);
           pdf.setTextColor(60, 60, 60);
-          pdf.setFont('helvetica', 'italic');
+          setFont('italic');
           const lines = pdf.splitTextToSize(text, contentWidth - 10);
           pdf.text(lines, margin + 8, yPosition);
           yPosition += lines.length * 5 + 2;
@@ -410,7 +414,7 @@ async function generateWithJsPDF(
             checkPageBreak(10);
             
             const bullet = tagName === 'ol' ? `${itemNum}.` : '•';
-            pdf.setFont('helvetica', 'normal');
+            setFont('normal');
             pdf.setFontSize(11);
             pdf.setTextColor(30, 30, 30);
             pdf.text(bullet, margin, yPosition);
@@ -432,7 +436,7 @@ async function generateWithJsPDF(
           
           checkPageBreak(15);
           
-          pdf.setFont('courier', 'normal');
+          pdf.setFont(isCJK ? fontFamily : 'courier', 'normal');
           pdf.setFontSize(9);
           pdf.setTextColor(50, 50, 50);
           
@@ -445,7 +449,7 @@ async function generateWithJsPDF(
           pdf.text(lines, margin + 4, yPosition);
           yPosition += codeHeight + 3;
           
-          pdf.setFont('helvetica', 'normal');
+          setFont('normal');
           break;
         }
         
@@ -522,11 +526,11 @@ async function generateWithJsPDF(
               const text = cell.textContent?.trim() || '';
               
               if (isHeader || cell.tagName === 'TH') {
-                pdf.setFont('helvetica', 'bold');
+                setFont('bold');
                 pdf.setFillColor(245, 245, 245);
                 pdf.rect(x, yPosition - 4, cellWidth, 8, 'F');
               } else {
-                pdf.setFont('helvetica', 'normal');
+                setFont('normal');
               }
               
               pdf.setTextColor(30, 30, 30);
@@ -559,7 +563,7 @@ async function generateWithJsPDF(
             if (text && text.length > 20) {
               pdf.setFontSize(11);
               pdf.setTextColor(30, 30, 30);
-              pdf.setFont('helvetica', 'normal');
+              setFont('normal');
               const lines = pdf.splitTextToSize(text, contentWidth);
               checkPageBreak(lines.length * 5);
               pdf.text(lines, margin, yPosition);
@@ -569,44 +573,6 @@ async function generateWithJsPDF(
         }
       }
     };
-    
-    // First pass: collect image positions from the HTML to understand their context
-    // This helps us render images at their proper location in the document
-    const imagePositions = new Map<string, number>();
-    let elementIndex = 0;
-    
-    function collectImagePositions(element: Element): void {
-      const tagName = element.tagName.toLowerCase();
-      elementIndex++;
-      
-      if (tagName === 'img') {
-        const imgEl = element as HTMLImageElement;
-        const src = imgEl.src || imgEl.getAttribute('data-src') || '';
-        if (src && !src.includes('data:image/svg')) {
-          imagePositions.set(src, elementIndex);
-        }
-      } else if (tagName === 'figure') {
-        const imgEl = element.querySelector('img') as HTMLImageElement;
-        if (imgEl) {
-          const src = imgEl.src || imgEl.getAttribute('data-src') || '';
-          if (src && !src.includes('data:image/svg')) {
-            imagePositions.set(src, elementIndex);
-          }
-        }
-      }
-      
-      // Recurse into children
-      for (const child of element.children) {
-        collectImagePositions(child);
-      }
-    }
-    
-    // Collect positions
-    for (const child of tempDiv.children) {
-      collectImagePositions(child);
-    }
-    
-    log.debug('[PDFGenerator] Found images with positions:', imagePositions.size);
     
     // Process all top-level elements - images are rendered INLINE where they appear
     if (useTextFallback) {
@@ -629,7 +595,7 @@ async function generateWithJsPDF(
           checkPageBreak(20);
           pdf.setFontSize(14);
           pdf.setTextColor(0, 0, 0);
-          pdf.setFont('helvetica', 'bold');
+          setFont('bold');
           const lines = pdf.splitTextToSize(headingText, contentWidth);
           pdf.text(lines, margin, yPosition);
           yPosition += lines.length * 6 + 3;
@@ -637,7 +603,7 @@ async function generateWithJsPDF(
           checkPageBreak(15);
           pdf.setFontSize(11);
           pdf.setTextColor(30, 30, 30);
-          pdf.setFont('helvetica', 'normal');
+          setFont('normal');
           const lines = pdf.splitTextToSize(text, contentWidth);
           pdf.text(lines, margin, yPosition);
           yPosition += lines.length * 5 + 4;
@@ -662,23 +628,11 @@ async function generateWithJsPDF(
           checkPageBreak(15);
           pdf.setFontSize(11);
           pdf.setTextColor(30, 30, 30);
-          pdf.setFont('helvetica', 'normal');
+          setFont('normal');
           const lines = pdf.splitTextToSize(text, contentWidth);
           pdf.text(lines, margin, yPosition);
           yPosition += lines.length * 5 + 4;
         }
-      }
-    }
-    
-    // Only add hero/featured images from extraction if they weren't in HTML
-    // These are images that were found separately (e.g., og:image, hero banners)
-    // and should be added at the beginning if not already present
-    if (options.includeImages && content.images.length > 0) {
-      // Only the first image from extraction might be a hero - add it only if not already rendered
-      const heroImage = content.images[0];
-      if (heroImage && !addedImageSrcs.has(heroImage.src) && !imagePositions.has(heroImage.src)) {
-        log.debug('[PDFGenerator] Hero image not in HTML content, was likely added at the top already');
-        // Hero images are typically added to the HTML by content-extractor, so skip
       }
     }
     
@@ -881,8 +835,10 @@ function processImageToCanvas(
  */
 async function resizeImageDataUrl(dataUrl: string): Promise<string | null> {
   return new Promise((resolve) => {
+    const timeout = setTimeout(() => resolve(dataUrl), 5000);
     const img = new Image();
     img.onload = () => {
+      clearTimeout(timeout);
       try {
         const result = processImageToCanvas(img, { maxWidth: 800, maxHeight: 1000 });
         resolve(result ?? dataUrl); // Return original if processing fails
@@ -891,7 +847,10 @@ async function resizeImageDataUrl(dataUrl: string): Promise<string | null> {
         resolve(dataUrl);
       }
     };
-    img.onerror = () => resolve(null);
+    img.onerror = () => {
+      clearTimeout(timeout);
+      resolve(null);
+    };
     img.src = dataUrl;
   });
 }
@@ -936,7 +895,7 @@ function loadImageViaCanvas(src: string, useCors: boolean): Promise<string | nul
 /**
  * Sanitize filename for PDF
  */
-function sanitizeFilename(name: string): string {
+export function sanitizeFilename(name: string): string {
   return name
     .replace(/[<>:"/\\|?*]/g, '') // Remove invalid characters
     .replace(/\s+/g, '_') // Replace spaces with underscores

--- a/tests/unit/cjk-font.test.ts
+++ b/tests/unit/cjk-font.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Unit Tests for CJK Font Utilities
+ *
+ * Tests `needsCJKFont` detection for various Unicode ranges
+ * and edge cases.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { needsCJKFont } from '../../src/shared/extraction/cjk-font';
+
+describe('needsCJKFont', () => {
+  describe('detects CJK characters', () => {
+    it.each([
+      ['Japanese Hiragana', 'こんにちは'],
+      ['Japanese Katakana', 'カタカナ'],
+      ['CJK Unified Ideographs (Chinese)', '你好世界'],
+      ['Korean Hangul syllables', '안녕하세요'],
+      ['Korean Jamo', '\u1100\u1161'], // 가
+      ['CJK punctuation', '〇〒〠'],
+      ['CJK Compatibility Ideographs', '\uF900\uFA0E'],
+      ['Bopomofo', '\u3100\u3105'],
+      ['Mixed Latin + CJK', 'Hello 世界'],
+      ['CJK Extension B (surrogate pair)', '\u{20000}'],
+    ])('%s: "%s"', (_label, input) => {
+      expect(needsCJKFont(input)).toBe(true);
+    });
+  });
+
+  describe('returns false for non-CJK text', () => {
+    it.each([
+      ['ASCII', 'Hello World'],
+      ['Latin extended', 'café résumé naïve'],
+      ['Cyrillic', 'Привет мир'],
+      ['Arabic', 'مرحبا بالعالم'],
+      ['Thai', 'สวัสดีชาวโลก'],
+      ['Emoji', '🎉🚀💡'],
+      ['empty string', ''],
+      ['numbers and symbols', '123 !@# $%^&*()'],
+    ])('%s: "%s"', (_label, input) => {
+      expect(needsCJKFont(input)).toBe(false);
+    });
+  });
+});

--- a/tests/unit/pdf-generator.test.ts
+++ b/tests/unit/pdf-generator.test.ts
@@ -1,0 +1,36 @@
+/**
+ * Unit Tests for PDF Generator Utilities
+ *
+ * Tests pure utility functions exported from pdf-generator.ts.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock dependencies that are not relevant for utility function tests
+vi.mock('jspdf', () => ({ jsPDF: vi.fn() }));
+vi.mock('../../src/shared/extraction/cjk-font', () => ({
+  needsCJKFont: vi.fn(),
+  registerCJKFont: vi.fn(),
+  CJK_FONT_FAMILY: 'NotoSansCJK',
+}));
+vi.mock('../../src/shared/utils/logger', () => ({
+  loggers: { extraction: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() } },
+}));
+
+import { sanitizeFilename } from '../../src/shared/extraction/pdf-generator';
+
+describe('sanitizeFilename', () => {
+  it.each([
+    ['removes invalid chars', 'file<>:"/\\|?*name', 'filename'],
+    ['replaces spaces with underscores', 'hello world test', 'hello_world_test'],
+    ['collapses multiple underscores', 'a___b___c', 'a_b_c'],
+    ['trims leading/trailing underscores', '___hello___', 'hello'],
+    ['truncates to 100 chars', 'a'.repeat(150), 'a'.repeat(100)],
+    ['handles combined transforms', '  My <Report> 2024  ', 'My_Report_2024'],
+    ['returns empty for all-invalid chars', '<>:"/\\|?*', ''],
+    ['preserves normal filenames', 'article-title_2024', 'article-title_2024'],
+    ['handles CJK filenames', '日本語の記事タイトル', '日本語の記事タイトル'],
+  ])('%s: "%s" → "%s"', (_label, input, expected) => {
+    expect(sanitizeFilename(input)).toBe(expected);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -91,6 +91,18 @@ export default defineConfig({
           });
         }
 
+        // Copy fonts
+        const fontsDir = resolve(__dirname, 'src/assets/fonts');
+        const destFontsDir = resolve(distDir, 'assets/fonts');
+        mkdirSync(destFontsDir, { recursive: true });
+
+        if (existsSync(fontsDir)) {
+          const fonts = readdirSync(fontsDir);
+          fonts.forEach((font) => {
+            copyFileSync(resolve(fontsDir, font), resolve(destFontsDir, font));
+          });
+        }
+
         // Copy icons for all browsers
         const iconsDir = resolve(__dirname, 'src/assets/icons');
         const destIconsDir = resolve(distDir, 'assets/icons');


### PR DESCRIPTION
Changes:
- Add cjk-font.ts: regex-based detection, fetch + base64 conversion with chunk-based processing, promise lock with GC after use
- Update pdf-generator.ts: integrate CJK font, add setFont helper that forces 'normal' style for CJK, add timeouts to image loaders, strip <script> tags, clean up dead code
- Update extraction.ts: CJK support in fallback generators, restore courier for code blocks when not in CJK mode
- Copy fonts to build output via vite config
- Add unit tests for needsCJKFont and sanitizeFilename

Works on both Chrome and Firefox (MV3).

### Proposed changes

* Bundle Noto Sans CJK font (Git LFS) and register it with jsPDF on demand
* Lazy-load only when CJK characters are detected in extracted content

### Related issues

* Closes #103

### How to test this PR

1. Install the extension from this branch
2. Navigate to a page with CJK content and generate a PDF snapshot
3. Verify characters render correctly (not mojibake)

Test pages:
- Japanese: https://www.jpcert.or.jp/at/2026/at260008.html
- Chinese (Simplified): https://www.cert.org.cn/
- Korean: https://pf.kakao.com/_xnJVxoxj/113570749

4. Also test a Latin-only page to confirm no regression (font should NOT be loaded)

### Checklist

- [x] The PR title follows the Conventional Commits convention `type(scope?): description (#issue)`
- [x] I signed my commits
- [x] This PR is linked to an issue
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [ ] I added/updated the relevant documentation
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

The font file is ~19 MB (TTF) tracked via Git LFS. It adds ~5 MB compressed to the extension package. It is only fetched at runtime when CJK characters are detected, so Latin-only PDFs have zero overhead.

**Alternatives considered:**
- **Host the font on our internal CDN** instead of bundling it, which would reduce extension package size but add a network dependency at runtime.
- **Use html2canvas for Firefox** instead of bundling the font. On Chrome we could use native `Page.printToPDF` (which respects system fonts), and fall back to html2canvas on Firefox. This would avoid storing the font entirely, but the Firefox output would be image-based with no selectable text.
