### PR TITLE
fix(openaev): omit cookies from API requests to avoid CSRF 403  (#169)

### DIFF
--- a/src/shared/api/openaev-client.ts
+++ b/src/shared/api/openaev-client.ts
@@ -94,6 +94,7 @@ export class OpenAEVClient {
   private async request<T>(endpoint: string, options: RequestInit = {}): Promise<T> {
     const response = await fetch(`${this.baseUrl}${endpoint}`, {
       ...options,
+      credentials: 'omit',
       headers: {
         'Content-Type': 'application/json',
         'Authorization': `Bearer ${this.token}`,


### PR DESCRIPTION
Adds `credentials: 'omit'` to the OpenAEV client fetch call so browser session cookies are not sent alongside the Bearer token, fixing 403 errors introduced by OpenAEV 2.3.4 CSRF protection.

Fixes #169
