### PR TITLE
feat(container): show creation failure to user in container creation (#175)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2370,9 +2370,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2390,9 +2387,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2410,9 +2404,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2430,9 +2421,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2450,9 +2438,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2470,9 +2455,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -7229,9 +7211,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7253,9 +7232,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7277,9 +7253,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -7301,9 +7274,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/background/handlers/container-handlers.ts
+++ b/src/background/handlers/container-handlers.ts
@@ -1,6 +1,6 @@
 /**
  * Container Message Handlers - Extracted from background/index.ts
- * 
+ *
  * These handlers process container-related messages for OpenCTI.
  * They are called directly from the main message handler switch statement.
  */
@@ -26,31 +26,30 @@ export async function handleCreateContainer(
     sendResponse(errorResponse('Not configured'));
     return;
   }
-  
+
   try {
     // Use specified platform or first available
     const platformId = payload.platformId || openCTIClients.keys().next().value as string | undefined;
-    
+
     if (!platformId) {
       sendResponse(errorResponse('No platform available'));
       return;
     }
-    
+
     const client = openCTIClients.get(platformId);
-    
+
     if (!client) {
       sendResponse(errorResponse('Platform not found'));
       return;
     }
-    
+
     // Step 0: Create any entities that don't exist yet
     const allEntityIds: string[] = [...(payload.entities || [])];
-    
     const failedEntities: Array<{ type: string; value: string; error: string }> = [];
 
     if (payload.entitiesToCreate && payload.entitiesToCreate.length > 0) {
       log.info(`Creating ${payload.entitiesToCreate.length} new entities for container...`);
-      
+
       for (const entityToCreate of payload.entitiesToCreate) {
         try {
           // Refang the value before creating (OpenCTI stores clean values)
@@ -63,7 +62,7 @@ export async function handleCreateContainer(
             value: cleanValue,
             name: cleanValue, // For SDOs that use name instead of value
           });
-          
+
           if (created?.id) {
             allEntityIds.push(created.id);
             log.debug(`Created entity: ${entityToCreate.type} = ${cleanValue} -> ${created.id}`);
@@ -77,30 +76,30 @@ export async function handleCreateContainer(
 
       log.info(`Created entities. Total entity IDs for container: ${allEntityIds.length}, failed: ${failedEntities.length}`);
     }
-    
+
     // Step 1: Create relationships if provided (before container, so we can include them)
     const createdRelationships: Array<{ id: string; relationship_type: string }> = [];
     if (payload.relationshipsToCreate && payload.relationshipsToCreate.length > 0 && allEntityIds.length > 0) {
       log.info(`Creating ${payload.relationshipsToCreate.length} relationships...`);
-      
+
       for (const rel of payload.relationshipsToCreate) {
         try {
           // Get entity IDs from indices
           const fromId = allEntityIds[rel.fromEntityIndex];
           const toId = allEntityIds[rel.toEntityIndex];
-          
+
           if (!fromId || !toId) {
             log.warn(`Invalid relationship indices: from=${rel.fromEntityIndex}, to=${rel.toEntityIndex}, available=${allEntityIds.length}`);
             continue;
           }
-          
+
           const relationship = await client.createStixCoreRelationship({
             fromId,
             toId,
             relationship_type: rel.relationship_type,
             description: rel.description,
           });
-          
+
           if (relationship?.id) {
             createdRelationships.push({
               id: relationship.id,
@@ -113,10 +112,10 @@ export async function handleCreateContainer(
           // Continue with other relationships
         }
       }
-      
+
       log.info(`Created ${createdRelationships.length} of ${payload.relationshipsToCreate.length} relationships`);
     }
-    
+
     // Step 2: Create external reference
     // For PDF sources: use external_id (the filename) instead of URL
     // For web pages: use URL as before
@@ -150,15 +149,15 @@ export async function handleCreateContainer(
         // Continue without external reference
       }
     }
-    
+
     // Step 3: Create the container with ALL IDs (entities + relationships)
     const allObjectIds = [
       ...allEntityIds,
       ...createdRelationships.map(r => r.id),
     ];
-    
+
     log.info(`${payload.updateContainerId ? 'Updating' : 'Creating'} container with ${allEntityIds.length} entities and ${createdRelationships.length} relationships`);
-    
+
     const container = await client.createContainer({
       type: payload.type as OCTIContainerType,
       name: payload.name,
@@ -181,7 +180,7 @@ export async function handleCreateContainer(
       published: payload.published,
       created: payload.created,
     });
-    
+
     // Step 4: Attach external reference to the container
     if (externalReferenceId && container.id) {
       try {
@@ -192,7 +191,7 @@ export async function handleCreateContainer(
         // Continue - container was created successfully
       }
     }
-    
+
     // Step 5: Upload PDF attachment if provided
     if (payload.pdfAttachment && container.id) {
       try {
@@ -202,7 +201,7 @@ export async function handleCreateContainer(
         for (let i = 0; i < binaryString.length; i++) {
           bytes[i] = binaryString.charCodeAt(i);
         }
-        
+
         await client.uploadFileToEntity(container.id, {
           name: payload.pdfAttachment.filename,
           data: bytes.buffer,
@@ -214,11 +213,11 @@ export async function handleCreateContainer(
         // Don't fail the whole operation, container was created successfully
       }
     }
-    
-    sendResponse({ 
-      success: true, 
-      data: { 
-        ...container, 
+
+    sendResponse({
+      success: true,
+      data: {
+        ...container,
         platformId: platformId,
         _createdRelationships: createdRelationships,
         failedEntities: failedEntities.length > 0 ? failedEntities : undefined,

--- a/src/background/handlers/container-handlers.ts
+++ b/src/background/handlers/container-handlers.ts
@@ -46,6 +46,8 @@ export async function handleCreateContainer(
     // Step 0: Create any entities that don't exist yet
     const allEntityIds: string[] = [...(payload.entities || [])];
     
+    const failedEntities: Array<{ type: string; value: string; error: string }> = [];
+
     if (payload.entitiesToCreate && payload.entitiesToCreate.length > 0) {
       log.info(`Creating ${payload.entitiesToCreate.length} new entities for container...`);
       
@@ -68,11 +70,12 @@ export async function handleCreateContainer(
           }
         } catch (entityError) {
           log.warn(`Failed to create entity ${entityToCreate.type}:${entityToCreate.value}:`, entityError);
-          // Continue with other entities
+          const errorMessage = entityError instanceof Error ? entityError.message : 'Failed to create entity';
+          failedEntities.push({ type: entityToCreate.type, value: entityToCreate.value, error: errorMessage });
         }
       }
-      
-      log.info(`Created entities. Total entity IDs for container: ${allEntityIds.length}`);
+
+      log.info(`Created entities. Total entity IDs for container: ${allEntityIds.length}, failed: ${failedEntities.length}`);
     }
     
     // Step 1: Create relationships if provided (before container, so we can include them)
@@ -218,7 +221,8 @@ export async function handleCreateContainer(
         ...container, 
         platformId: platformId,
         _createdRelationships: createdRelationships,
-      } 
+        failedEntities: failedEntities.length > 0 ? failedEntities : undefined,
+      }
     });
   } catch (error) {
     sendResponse({

--- a/src/background/handlers/container-handlers.ts
+++ b/src/background/handlers/container-handlers.ts
@@ -9,6 +9,7 @@ import { OpenCTIClient } from '../../shared/api/opencti-client';
 import { refangIndicator } from '../../shared/detection/patterns';
 import { errorResponse, type SendResponseFn } from '../../shared/types/common';
 import type { CreateContainerPayload } from '../../shared/types/messages';
+import type { FailedEntityImport } from '../../shared/types/scan';
 import { loggers } from '../../shared/utils/logger';
 import type { OCTIContainerType } from '../../shared/types/opencti';
 
@@ -43,39 +44,41 @@ export async function handleCreateContainer(
       return;
     }
 
-    // Step 0: Create any entities that don't exist yet
-    const allEntityIds: string[] = [...(payload.entities || [])];
-    const failedEntities: Array<{ type: string; value: string; error: string }> = [];
+    // Step 0: Create any entities that don't exist yet.
+    // Each entry maps 1-to-1 with entitiesToCreate so relationship indices stay stable:
+    // a failed creation leaves null in the slot rather than shifting subsequent entries.
+    type CreationResult =
+      | { status: 'created'; id: string }
+      | { status: 'failed'; type: string; value: string; error: string };
 
-    if (payload.entitiesToCreate && payload.entitiesToCreate.length > 0) {
-      log.info(`Creating ${payload.entitiesToCreate.length} new entities for container...`);
-
-      for (const entityToCreate of payload.entitiesToCreate) {
+    const creationResults: CreationResult[] = await Promise.all(
+      (payload.entitiesToCreate || []).map(async (e): Promise<CreationResult> => {
         try {
-          // Refang the value before creating (OpenCTI stores clean values)
-          const cleanValue = refangIndicator(entityToCreate.value);
-          // Use createEntity instead of createObservable to handle both
-          // STIX Domain Objects (SDOs) like Vulnerability, Malware, Threat-Actor
-          // and STIX Cyber Observables (SCOs) like IP, Domain, Hash
-          const created = await client.createEntity({
-            type: entityToCreate.type,
-            value: cleanValue,
-            name: cleanValue, // For SDOs that use name instead of value
-          });
-
-          if (created?.id) {
-            allEntityIds.push(created.id);
-            log.debug(`Created entity: ${entityToCreate.type} = ${cleanValue} -> ${created.id}`);
-          }
-        } catch (entityError) {
-          log.warn(`Failed to create entity ${entityToCreate.type}:${entityToCreate.value}:`, entityError);
-          const errorMessage = entityError instanceof Error ? entityError.message : 'Failed to create entity';
-          failedEntities.push({ type: entityToCreate.type, value: entityToCreate.value, error: errorMessage });
+          const cleanValue = refangIndicator(e.value);
+          const created = await client.createEntity({ type: e.type, value: cleanValue, name: cleanValue });
+          log.debug(`Created entity: ${e.type} = ${cleanValue} -> ${created.id}`);
+          return { status: 'created', id: created.id };
+        } catch (err) {
+          const error = err instanceof Error ? err.message : 'Failed to create entity';
+          log.warn(`Failed to create entity ${e.type}:${e.value}:`, err);
+          return { status: 'failed', type: e.type, value: e.value, error };
         }
-      }
+      })
+    );
 
-      log.info(`Created entities. Total entity IDs for container: ${allEntityIds.length}, failed: ${failedEntities.length}`);
-    }
+    const failedEntities: FailedEntityImport[] = creationResults
+      .filter((r) => r.status === 'failed')
+      .map(({ type, value, error }) => ({ type, value, error }));
+
+    // Slot-indexed array for relationship resolution: null where creation failed.
+    // Prefixed with pre-existing entity ids so UI-side indices remain valid.
+    const entitySlots: Array<string | null> = [
+      ...(payload.entities || []),
+      ...creationResults.map(r => (r.status === 'created' ? r.id : null)),
+    ];
+
+    // Flat list of all valid ids for the container objects list.
+    const allEntityIds = entitySlots.filter((id): id is string => id !== null);
 
     // Step 1: Create relationships if provided (before container, so we can include them)
     const createdRelationships: Array<{ id: string; relationship_type: string }> = [];
@@ -84,12 +87,12 @@ export async function handleCreateContainer(
 
       for (const rel of payload.relationshipsToCreate) {
         try {
-          // Get entity IDs from indices
-          const fromId = allEntityIds[rel.fromEntityIndex];
-          const toId = allEntityIds[rel.toEntityIndex];
+          // Get entity IDs from slots — null means that entity failed to create
+          const fromId = entitySlots[rel.fromEntityIndex];
+          const toId = entitySlots[rel.toEntityIndex];
 
           if (!fromId || !toId) {
-            log.warn(`Invalid relationship indices: from=${rel.fromEntityIndex}, to=${rel.toEntityIndex}, available=${allEntityIds.length}`);
+            log.warn(`Skipping relationship: entity at index ${!fromId ? rel.fromEntityIndex : rel.toEntityIndex} was not created`);
             continue;
           }
 

--- a/src/panel/App.tsx
+++ b/src/panel/App.tsx
@@ -79,11 +79,11 @@ const App: React.FC = () => {
     openctiPlatforms, openaevPlatforms,
     loadPlatforms,
   } = usePlatforms();
-  
+
   // Keep ref for openctiPlatforms (used in event handlers)
   const openctiPlatformsRef = React.useRef<PlatformInfo[]>([]);
   React.useEffect(() => { openctiPlatformsRef.current = openctiPlatforms; }, [openctiPlatforms]);
-  
+
   // Test platform connections for EE status when platforms are loaded
   const platformsTestedRef = React.useRef(false);
   React.useEffect(() => {
@@ -100,7 +100,7 @@ const App: React.FC = () => {
               return;
             }
             if (testResponse?.success) {
-              setAvailablePlatforms(prev => prev.map(p => 
+              setAvailablePlatforms(prev => prev.map(p =>
                 p.id === platform.id ? { ...p, connected: true, version: testResponse.data?.version, isEnterprise: testResponse.data?.enterprise_edition } : p
               ));
             } else {
@@ -300,10 +300,10 @@ const App: React.FC = () => {
   const handleInvestigationScanRef = React.useRef<(platformId: string) => Promise<void>>(async () => {});
 
   // Container actions hook
-  const { 
-    handleAddEntities, 
-    handleCreateContainer, 
-    handleGenerateAIDescription 
+  const {
+    handleAddEntities,
+    handleCreateContainer,
+    handleGenerateAIDescription
   } = useContainerActions({
     openctiPlatforms,
     availablePlatforms,
@@ -459,7 +459,7 @@ const App: React.FC = () => {
   const loadLabelsAndMarkings = (platformId?: string) => {
     if (typeof chrome === 'undefined' || !chrome.runtime?.sendMessage) return;
     const targetPlatformId = platformId || selectedPlatformId;
-    
+
     if (!labelsLoaded) {
       // Use SEARCH_LABELS with limit of 10 for initial load
       chrome.runtime.sendMessage({ type: 'SEARCH_LABELS', payload: { search: '', first: 10, platformId: targetPlatformId } }, (response) => {
@@ -475,7 +475,7 @@ const App: React.FC = () => {
         }
       });
     }
-    
+
     if (!markingsLoaded) {
       chrome.runtime.sendMessage({ type: 'FETCH_MARKINGS', payload: { platformId: targetPlatformId } }, (response) => {
         if (chrome.runtime.lastError) return;
@@ -485,7 +485,7 @@ const App: React.FC = () => {
         }
       });
     }
-    
+
     // Load vocabularies
     const vocabTypes = [
       { type: 'report_types_ov', setter: setAvailableReportTypes },
@@ -494,14 +494,14 @@ const App: React.FC = () => {
       { type: 'case_priority_ov', setter: setAvailablePriorities },
       { type: 'incident_response_types_ov', setter: setAvailableResponseTypes },
     ];
-    
+
     vocabTypes.forEach(({ type, setter }) => {
       chrome.runtime.sendMessage({ type: 'FETCH_VOCABULARY', payload: { category: type, platformId: targetPlatformId } }, (response) => {
         if (chrome.runtime.lastError) return;
         if (response?.success && response.data) setter(response.data);
       });
     });
-    
+
     chrome.runtime.sendMessage({ type: 'SEARCH_IDENTITIES', payload: { search: '', first: 50, platformId: targetPlatformId } }, (response) => {
       if (chrome.runtime.lastError) return;
       if (response?.success && response.data) setAvailableAuthors(response.data);
@@ -512,7 +512,7 @@ const App: React.FC = () => {
   const fetchEntityContainers = async (entityId: string, platformId?: string) => {
     if (typeof chrome === 'undefined' || !chrome.runtime?.sendMessage) return;
     if (!entityId) return;
-    
+
     setLoadingContainers(true);
     setEntityContainers([]);
     try {
@@ -533,20 +533,20 @@ const App: React.FC = () => {
   // Helper to check if current tab is a PDF or PDF scanner page
   const checkAndHandlePdfPage = useCallback(async (): Promise<boolean> => {
     if (typeof chrome === 'undefined' || !chrome.tabs) return false;
-    
+
     try {
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
       if (!tab?.url) return false;
-      
+
       const url = tab.url;
       const extensionId = chrome.runtime.id;
-      
+
       // Check if already on PDF scanner page
       if (url.startsWith(`chrome-extension://${extensionId}/pdf-scanner/`) ||
           url.startsWith(`moz-extension://${extensionId}/pdf-scanner/`)) {
         // Already on PDF scanner - trigger rescan
         log.debug('Triggering PDF scanner rescan, isSplitScreenMode:', isSplitScreenMode);
-        
+
         // In iframe mode (panel embedded in PDF scanner), use postMessage directly
         // chrome.tabs.sendMessage doesn't work for extension pages
         if (!isSplitScreenMode) {
@@ -556,9 +556,9 @@ const App: React.FC = () => {
         } else if (tab.id) {
           // In split screen mode, go through background
           try {
-            const response = await chrome.runtime.sendMessage({ 
-              type: 'PDF_SCANNER_RESCAN', 
-              payload: { tabId: tab.id } 
+            const response = await chrome.runtime.sendMessage({
+              type: 'PDF_SCANNER_RESCAN',
+              payload: { tabId: tab.id }
             });
             log.debug('PDF_SCANNER_RESCAN response:', response);
           } catch (e) {
@@ -567,16 +567,16 @@ const App: React.FC = () => {
         }
         return true;
       }
-      
+
       // Check if on a raw PDF page (including Chrome's built-in PDF viewer)
       // Chrome's PDF viewer uses extension ID: mhjfbmdgcfjbbpaeojofohoefgiehjai
       const lowerUrl = url.toLowerCase();
-      const isPdfPage = lowerUrl.endsWith('.pdf') || 
-        lowerUrl.includes('.pdf?') || 
+      const isPdfPage = lowerUrl.endsWith('.pdf') ||
+        lowerUrl.includes('.pdf?') ||
         lowerUrl.includes('.pdf#') ||
         lowerUrl.includes('mhjfbmdgcfjbbpaeojofohoefgiehjai') || // Chrome's built-in PDF viewer
         url.match(/\/[^/]+\.pdf($|\?|#)/i) !== null;
-      
+
       if (isPdfPage) {
         // Open PDF scanner for this URL
         // For Chrome's PDF viewer, extract the actual PDF URL
@@ -588,7 +588,7 @@ const App: React.FC = () => {
             pdfUrl = decodeURIComponent(match[1]);
           }
         }
-        
+
         const response = await chrome.runtime.sendMessage({
           type: 'OPEN_PDF_SCANNER',
           payload: { pdfUrl },
@@ -598,7 +598,7 @@ const App: React.FC = () => {
         }
         return true;
       }
-      
+
       return false;
     } catch (error) {
       log.error('Error checking PDF page:', error);
@@ -611,18 +611,18 @@ const App: React.FC = () => {
     if (typeof chrome === 'undefined' || !chrome.tabs) return;
     const targetPlatformId = platformId || investigationPlatformId;
     if (!targetPlatformId && openctiPlatforms.length > 1) return;
-    
+
     // Check if on PDF page first - PDF pages should use the standard scan which is shown in panel
     const isPdf = await checkAndHandlePdfPage();
     if (isPdf) return;
-    
+
     setInvestigationScanning(true);
     setInvestigationEntities([]);
-    
+
     try {
       const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
       if (tab?.id) {
-        chrome.tabs.sendMessage(tab.id, { 
+        chrome.tabs.sendMessage(tab.id, {
           type: 'SCAN_FOR_INVESTIGATION',
           payload: { platformId: targetPlatformId || openctiPlatforms[0]?.id },
         });
@@ -651,7 +651,7 @@ const App: React.FC = () => {
       window.parent.postMessage({ type: 'XTM_PDF_SCANNER_RESCAN' }, '*');
       return;
     }
-    
+
     // In split screen mode with PDF view detected, open PDF scanner for the current tab
     // This handles the case when user is on a native PDF page with the sidebar open
     if (isPdfView && isSplitScreenMode) {
@@ -659,11 +659,11 @@ const App: React.FC = () => {
       const isPdf = await checkAndHandlePdfPage();
       if (isPdf) return;
     }
-    
+
     // Check if on PDF page first (fallback for other cases)
     const isPdf = await checkAndHandlePdfPage();
     if (isPdf) return;
-    
+
     setIsScanning(true);
     sendToContentScript('SCAN_ALL');
   };
@@ -702,26 +702,26 @@ const App: React.FC = () => {
         if (response.data?.theme) {
           setMode(response.data.theme === 'light' ? 'light' : 'dark');
         }
-        
+
         // Update split screen mode from settings (fallback if detection fails)
         if (response.data?.splitScreenMode !== undefined) {
           // If in iframe but setting is true, we might be in transition - use detected value
           // If not in iframe, we're definitely in side panel
           setIsSplitScreenMode(isInSidePanel || response.data.splitScreenMode);
         }
-        
+
         const ai = response.data?.ai;
         const aiAvailable = !!(ai?.xtmOneUrl && ai?.apiToken);
         setAiSettings({ enabled: aiAvailable, available: aiAvailable });
       }
     });
-    
+
     // Load platforms via hook
     loadPlatforms();
 
     window.addEventListener('message', handleMessage);
     window.parent.postMessage({ type: 'XTM_PANEL_READY' }, '*');
-    
+
     // Small delay before GET_PANEL_STATE to ensure React is fully initialized
     // This helps with native side panel where timing can be critical
     setTimeout(() => {
@@ -738,7 +738,7 @@ const App: React.FC = () => {
         hasRestoredState.current = true;
       });
     }, 50);
-    
+
     // Listen for runtime messages (for split screen mode)
     // In split screen mode, content script sends messages via chrome.runtime
     const handleRuntimeMessage = (message: { type: string; payload?: unknown }) => {
@@ -748,12 +748,12 @@ const App: React.FC = () => {
         handlePanelState(panelMessage);
       }
     };
-    
+
     chrome.runtime.onMessage.addListener(handleRuntimeMessage);
-    
+
     // Track last processed message timestamp to avoid processing stale messages
     let lastProcessedMessageTime = 0;
-    
+
     // Check for pending panel state from session storage (split screen mode in Chrome/Edge)
     // This handles the case where context menu was used but panel wasn't ready yet
     const checkPendingState = () => {
@@ -771,7 +771,7 @@ const App: React.FC = () => {
         // Session storage not available
       });
     };
-    
+
     // Update handleMessage to use timestamp tracking
     const originalHandleMessage = handleMessage;
     const handleMessageWithTimestamp = (event: MessageEvent) => {
@@ -783,10 +783,10 @@ const App: React.FC = () => {
     };
     window.removeEventListener('message', handleMessage);
     window.addEventListener('message', handleMessageWithTimestamp);
-    
+
     // Initial check after a small delay (same as GET_PANEL_STATE)
     setTimeout(() => checkPendingState(), 100);
-    
+
     // Poll for pending state a few times (for split screen mode in Chrome/Edge)
     // Use shorter intervals for faster response
     let pollCount = 0;
@@ -799,7 +799,7 @@ const App: React.FC = () => {
       }
       checkPendingState();
     }, 200);
-    
+
     // Listen for storage changes
     const handleStorageChange = (changes: { [key: string]: chrome.storage.StorageChange }, areaName: string) => {
       if (areaName === 'local' && changes.settings) {
@@ -807,7 +807,7 @@ const App: React.FC = () => {
         if (newSettings) {
           // Reload platforms via hook (handles platform state updates)
           loadPlatforms();
-          
+
           // Update AI settings
           const ai = newSettings.ai;
           const aiAvailable = !!(ai?.xtmOneUrl && ai?.apiToken);
@@ -815,7 +815,7 @@ const App: React.FC = () => {
         }
       }
     };
-    
+
     chrome.storage.onChanged.addListener(handleStorageChange);
 
     return () => {
@@ -840,38 +840,38 @@ const App: React.FC = () => {
           // Ignore - cross-origin issues
         }
       }
-      
+
       // Also try chrome.tabs.query as a fallback (works better in split screen mode)
       if (typeof chrome === 'undefined' || !chrome.tabs?.query) return;
-      
+
       try {
         const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
         if (tab?.url) {
           const url = tab.url;
           const extensionId = chrome.runtime.id;
-          
+
           // Check if on PDF scanner page
           const isPdfScannerPage = url.startsWith(`chrome-extension://${extensionId}/pdf-scanner/`) ||
                                    url.startsWith(`moz-extension://${extensionId}/pdf-scanner/`);
-          
+
           // Check if on native PDF page (including Chrome's built-in PDF viewer)
           // Chrome's PDF viewer uses extension ID: mhjfbmdgcfjbbpaeojofohoefgiehjai
           const lowerUrl = url.toLowerCase();
-          const isNativePdf = lowerUrl.endsWith('.pdf') || 
-                              lowerUrl.includes('.pdf?') || 
+          const isNativePdf = lowerUrl.endsWith('.pdf') ||
+                              lowerUrl.includes('.pdf?') ||
                               lowerUrl.includes('.pdf#') ||
                               lowerUrl.includes('mhjfbmdgcfjbbpaeojofohoefgiehjai') || // Chrome's built-in PDF viewer
                               url.match(/\/[^/]+\.pdf($|\?|#)/i) !== null;
-          
+
           setIsPdfView(isPdfScannerPage || isNativePdf);
         }
       } catch (e) {
         // Ignore - may not have tab access
       }
     };
-    
+
     checkPdfView();
-    
+
     // In split screen mode, also check after a delay to handle initial load timing issues
     // The PDF scanner tab might not be fully ready when the panel first loads
     if (isSplitScreenMode) {
@@ -880,13 +880,13 @@ const App: React.FC = () => {
         setTimeout(() => checkPdfView(), delay);
       });
     }
-    
+
     // Re-check when tab changes (listen for tab activation)
     const handleTabActivated = () => checkPdfView();
     if (typeof chrome !== 'undefined' && chrome.tabs?.onActivated) {
       chrome.tabs.onActivated.addListener(handleTabActivated);
     }
-    
+
     // Re-check when the current tab's URL changes (e.g., navigating to a PDF)
     const handleTabUpdated = (tabId: number, changeInfo: { url?: string; status?: string }) => {
       // Only check if URL changed and tab is in the current window
@@ -902,7 +902,7 @@ const App: React.FC = () => {
     if (typeof chrome !== 'undefined' && chrome.tabs?.onUpdated) {
       chrome.tabs.onUpdated.addListener(handleTabUpdated);
     }
-    
+
     // Re-check when page visibility changes (tab becomes active)
     const handleVisibilityChange = () => {
       if (document.visibilityState === 'visible') {
@@ -910,7 +910,7 @@ const App: React.FC = () => {
       }
     };
     document.addEventListener('visibilitychange', handleVisibilityChange);
-    
+
     return () => {
       if (typeof chrome !== 'undefined' && chrome.tabs?.onActivated) {
         chrome.tabs.onActivated.removeListener(handleTabActivated);
@@ -989,7 +989,7 @@ const App: React.FC = () => {
     if (data.payload?.theme && (data.payload.theme === 'dark' || data.payload.theme === 'light')) {
       if (data.payload.theme !== mode) setMode(data.payload.theme);
     }
-    
+
     switch (data.type) {
       case 'SHOW_ENTITY':
       case 'SHOW_ENTITY_PANEL':
@@ -1086,7 +1086,7 @@ const App: React.FC = () => {
   const handleShowEntity = async (payload: any) => {
     setEntityContainers([]);
     setEntityFromSearchMode(null);
-    
+
     // Restore scan results from payload if available (needed when panel was closed and reopened)
     if (payload?.scanResults) {
       const { entities } = processScanResults(payload.scanResults);
@@ -1095,19 +1095,19 @@ const App: React.FC = () => {
         scanResultsEntitiesRef.current = entities;
       }
     }
-    
+
     // Use fromScanResults flag from payload if available, otherwise check local scan results
     const hasScanResults = payload?.fromScanResults === true || scanResultsEntitiesRef.current.length > 0;
     setEntityFromScanResults(hasScanResults);
-    
+
     const entityId = payload?.entityData?.id || payload?.entityId || payload?.id;
     const entityType = payload?.entityData?.entity_type || payload?.type || payload?.entity_type;
     const platformId = payload?.platformId;
     const platformMatches = payload?.platformMatches || payload?.entityData?.platformMatches;
-    
+
     // Build multi-platform results
     let multiResults: MultiPlatformResult[] = [];
-    
+
     // Handle multi-platform results with platform fallback (same as CommonScanResultsView)
     if (platformMatches && platformMatches.length > 0) {
       for (const match of platformMatches) {
@@ -1117,7 +1117,7 @@ const App: React.FC = () => {
           // Fall back to finding any platform of the same type
           platform = availablePlatforms.find(p => p.type === match.platformType);
         }
-        
+
         const matchPlatformType = (match.platformType || platform?.type || 'opencti') as PlatformType;
         const matchType = match.type || match.entityData?.entity_type || payload?.type || entityType || '';
         // Remove any existing prefix and get the clean type
@@ -1125,10 +1125,10 @@ const App: React.FC = () => {
         const cleanType = parsed ? parsed.entityType : matchType;
         // Apply proper prefix based on platform type
         const displayType = prefixEntityType(cleanType, matchPlatformType);
-        
+
         // Use the found platform's ID if available
         const resolvedPlatformId = platform?.id || match.platformId;
-        
+
         multiResults.push({
           platformId: resolvedPlatformId,
           platformName: platform?.name || match.platformId,
@@ -1148,7 +1148,7 @@ const App: React.FC = () => {
           } as EntityData,
         });
       }
-      
+
       const sorted = sortPlatformResults(multiResults, availablePlatforms);
       multiResults = sorted;
       setMultiPlatformResults(sorted);
@@ -1169,7 +1169,7 @@ const App: React.FC = () => {
       setCurrentPlatformIndex(0);
       updateCurrentPlatformIndexRef(0);
     }
-    
+
     // Update platform URL
     if (platformId && availablePlatforms.length > 0) {
       const platform = availablePlatforms.find(p => p.id === platformId);
@@ -1178,17 +1178,17 @@ const App: React.FC = () => {
         setSelectedPlatformId(platform.id);
       }
     }
-    
+
     // Determine platform type for initial entity
     const parsedType = entityType ? parsePrefixedType(entityType) : null;
     const isNonDefaultPlatform = parsedType !== null;
     const entityPlatformType = parsedType?.platformType || 'opencti';
-    
+
     // Set initial entity and panel mode
     const initialEntity = multiResults[0]?.entity || { ...payload, platformType: entityPlatformType, isNonDefaultPlatform: isNonDefaultPlatform };
     setEntity(initialEntity);
     setPanelMode(payload?.existsInPlatform || multiResults.length > 0 ? 'entity' : 'not-found');
-    
+
     // Always fetch entity details for the first platform if entity exists
     // This ensures fresh data regardless of what's in the cache
     if (multiResults.length > 0 && multiResults[0] && typeof chrome !== 'undefined' && chrome.runtime?.sendMessage) {
@@ -1197,10 +1197,10 @@ const App: React.FC = () => {
       const firstEntityType = ((firstResult.entity.entity_type || firstResult.entity.type || '') as string).replace(/^oaev-/, '');
       const firstPlatformId = firstResult.platformId;
       const firstPlatformType = (firstResult.entity.platformType || 'opencti') as string;
-      
+
       if (firstEntityId && firstPlatformId) {
         setEntityDetailsLoading(true);
-        
+
         chrome.runtime.sendMessage({
           type: 'GET_ENTITY_DETAILS',
           payload: { id: firstEntityId, entityType: firstEntityType, platformId: firstPlatformId, platformType: firstPlatformType },
@@ -1208,14 +1208,14 @@ const App: React.FC = () => {
           setEntityDetailsLoading(false);
           if (chrome.runtime.lastError) return;
           if (currentPlatformIndexRef.current !== 0) return;
-          
+
           if (response?.success && response.data) {
-            const fullEntity = { 
+            const fullEntity = {
               ...firstResult.entity, ...response.data, entityData: response.data, existsInPlatform: true,
               platformId: firstPlatformId, platformType: firstPlatformType, isNonDefaultPlatform: firstPlatformType !== 'opencti',
             };
             setEntity(fullEntity);
-            setMultiPlatformResults(prev => prev.map((r, i) => 
+            setMultiPlatformResults(prev => prev.map((r, i) =>
               i === 0 ? { ...r, entity: { ...r.entity, ...response.data, entityData: response.data } } : r
             ));
             multiPlatformResultsRef.current = multiPlatformResultsRef.current.map((r, i) =>
@@ -1240,10 +1240,10 @@ const App: React.FC = () => {
     const pdfFileName = payload?.pdfFileName || '';
     const isPdfSourcePayload = payload?.isPdfSource || false;
     const containerDescription = payload?.pageDescription || generateDescription(pageContent);
-    
+
     // For PDF source, use the PDF title as container name, not the page title (which is "Filigran XTM - PDF scanner")
     const containerName = isPdfSourcePayload && pageTitle ? pageTitle : pageTitle;
-    
+
     setContainerForm({ name: containerName, description: containerDescription, content: cleanHtmlContent(pageHtmlContent) });
     setEntitiesToAdd(payload?.entities || []);
     setCurrentPageUrl(pageUrl);
@@ -1252,7 +1252,7 @@ const App: React.FC = () => {
     setIsPdfSource(isPdfSourcePayload);
     setContainerWorkflowOrigin('direct');
     setExistingContainers([]);
-    
+
     const goToNextStep = () => {
       const platforms = openctiPlatformsRef.current;
       if (platforms.length > 1) {
@@ -1265,11 +1265,11 @@ const App: React.FC = () => {
         setPanelMode('container-type');
       }
     };
-    
+
     if (pageUrl && typeof chrome !== 'undefined' && chrome.runtime?.sendMessage) {
       setCheckingExisting(true);
       setPanelMode('loading');
-      
+
       chrome.runtime.sendMessage({ type: 'FIND_CONTAINERS_BY_URL', payload: { url: pageUrl } }, (response) => {
         setCheckingExisting(false);
         if (chrome.runtime.lastError) { goToNextStep(); return; }
@@ -1310,7 +1310,7 @@ const App: React.FC = () => {
     clearEntityState();
     setEntityContainers([]);
     if (payload?.theme && (payload.theme === 'dark' || payload.theme === 'light')) setMode(payload.theme);
-    
+
     setAtomicTestingTargets(payload?.targets || []);
     setSelectedAtomicTarget(null);
     setAtomicTestingPlatformSelected(false);
@@ -1332,14 +1332,14 @@ const App: React.FC = () => {
     clearEntityState();
     setEntityContainers([]);
     const entities = payload?.entities || [];
-    
+
     // Deduplicate entities by type + name/value combination
     const seenEntities = new Map<string, any>();
     for (const e of entities) {
       const type = e.type || e.entity_type;
       const name = e.name || e.value || '';
       const dedupeKey = `${type}:${name.toLowerCase()}`;
-      
+
       if (!seenEntities.has(dedupeKey)) {
         seenEntities.set(dedupeKey, {
           id: e.entityId || e.id,
@@ -1351,7 +1351,7 @@ const App: React.FC = () => {
         });
       }
     }
-    
+
     setInvestigationEntities(Array.from(seenEntities.values()));
     setInvestigationScanning(false);
     setInvestigationTypeFilter('all');
@@ -1362,7 +1362,7 @@ const App: React.FC = () => {
     clearEntityState();
     setEntityContainers([]);
     setEntityFromSearchMode(null);
-    
+
     const { entities, pageContent, pageTitle, pageUrl } = processScanResults(payload || {});
     setScanResultsEntities(entities);
     setScanResultsTypeFilter('all');
@@ -1377,7 +1377,7 @@ const App: React.FC = () => {
   // Handler: Scan Results with initial filter (e.g., from clicking AI highlight)
   const handleScanResultsWithFilter = (payload: any) => {
     const { initialFilter, ...rest } = payload || {};
-    
+
     // If we already have scan results loaded and just need to change filter
     if (scanResultsEntities.length > 0 && panelMode === 'scan-results') {
       // Just update the filter
@@ -1389,7 +1389,7 @@ const App: React.FC = () => {
       clearEntityState();
       setEntityContainers([]);
       setEntityFromSearchMode(null);
-      
+
       const { entities, pageContent, pageTitle, pageUrl } = processScanResults(rest || {});
       setScanResultsEntities(entities);
       setScanResultsTypeFilter('all');
@@ -1430,7 +1430,7 @@ const App: React.FC = () => {
   const handleShowScenario = async (payload: any) => {
     const { attackPatterns, pageTitle, pageUrl, pageDescription, theme: themeFromPayload } = payload || {};
     if (themeFromPayload && (themeFromPayload === 'dark' || themeFromPayload === 'light')) setMode(themeFromPayload);
-    
+
     setCurrentPageUrl(pageUrl || '');
     setCurrentPageTitle(pageTitle || '');
     setScenarioForm({
@@ -1455,7 +1455,7 @@ const App: React.FC = () => {
     setScenarioAIContext('');
     setScenarioAIGeneratedScenario(null);
     setScenarioRawAttackPatterns(attackPatterns || []);
-    
+
     let currentPlatforms = availablePlatformsRef.current;
     if (currentPlatforms.length === 0 && typeof chrome !== 'undefined' && chrome.runtime?.sendMessage) {
       try {
@@ -1479,7 +1479,7 @@ const App: React.FC = () => {
         log.warn('Failed to fetch platforms:', error);
       }
     }
-    
+
     const oaevPlatformsList = currentPlatforms.filter(p => p.type === 'openaev');
     if (oaevPlatformsList.length > 1) {
       setScenarioPlatformSelected(false);
@@ -1492,7 +1492,7 @@ const App: React.FC = () => {
       setScenarioPlatformId(singlePlatformId);
       setSelectedPlatformId(singlePlatformId);
       setPlatformUrl(oaevPlatformsList[0].url);
-      
+
       if (typeof chrome !== 'undefined' && chrome.runtime?.sendMessage) {
         Promise.all([
           chrome.runtime.sendMessage({ type: 'FETCH_OAEV_ASSETS', payload: { platformId: singlePlatformId } }),
@@ -1504,11 +1504,11 @@ const App: React.FC = () => {
           if (teamsRes?.success) setScenarioTeams(teamsRes.data || []);
         }).catch((error) => log.error('Failed to fetch scenario targets:', error));
       }
-      
+
       setScenarioSelectedAsset(null);
       setScenarioSelectedAssetGroup(null);
       setScenarioSelectedTeam(null);
-      
+
       const filteredPatterns = (attackPatterns || []).filter((ap: any) => !ap.platformId || ap.platformId === singlePlatformId);
       if (filteredPatterns.length > 0 && typeof chrome !== 'undefined' && chrome.runtime?.sendMessage) {
         setScenarioLoading(true);
@@ -1596,10 +1596,10 @@ const App: React.FC = () => {
     if (!addToScanResultsText || !addToScanResultsEntityType) return;
 
     const trimmedValue = addToScanResultsText.trim().toLowerCase();
-    
+
     // Check for duplicate: same type and same value (case-insensitive)
-    const isDuplicate = scanResultsEntitiesRef.current.some(entity => 
-      entity.type === addToScanResultsEntityType && 
+    const isDuplicate = scanResultsEntitiesRef.current.some(entity =>
+      entity.type === addToScanResultsEntityType &&
       (entity.name?.toLowerCase() === trimmedValue || entity.value?.toLowerCase() === trimmedValue)
     );
 
@@ -1659,7 +1659,7 @@ const App: React.FC = () => {
       case 'entity': {
         const entityType = (entity as any)?.type || '';
         const isNonDefaultPlatformEntity = (entity as any)?.isNonDefaultPlatform || (entity as any)?.platformType !== 'opencti' || parsePrefixedType(entityType) !== null;
-        
+
         if (isNonDefaultPlatformEntity) {
           return <OAEVEntityView mode={mode} entity={entity} setEntity={setEntity} entityDetailsLoading={entityDetailsLoading} setEntityDetailsLoading={setEntityDetailsLoading} availablePlatforms={availablePlatforms} multiPlatformResults={multiPlatformResults} setMultiPlatformResults={setMultiPlatformResults} currentPlatformIndex={currentPlatformIndex} setCurrentPlatformIndex={setCurrentPlatformIndex} currentPlatformIndexRef={currentPlatformIndexRef} multiPlatformResultsRef={multiPlatformResultsRef} setPlatformUrl={setPlatformUrl} setSelectedPlatformId={setSelectedPlatformId} entityFromSearchMode={entityFromSearchMode} setEntityFromSearchMode={setEntityFromSearchMode} entityFromScanResults={entityFromScanResults} setEntityFromScanResults={setEntityFromScanResults} setPanelMode={setPanelMode} handleCopyValue={handleCopyValue} />;
         }
@@ -1682,8 +1682,8 @@ const App: React.FC = () => {
       case 'scenario-overview':
       case 'scenario-form': return <OAEVScenarioView mode={mode} panelMode={panelMode as 'scenario-overview' | 'scenario-form'} availablePlatforms={availablePlatforms} selectedPlatformId={selectedPlatformId} setSelectedPlatformId={setSelectedPlatformId} setPlatformUrl={setPlatformUrl} setPanelMode={setPanelMode} showToast={showToast} currentPageTitle={currentPageTitle} currentPageUrl={currentPageUrl} aiSettings={aiSettings} submitting={submitting} setSubmitting={setSubmitting} aiSelectingInjects={aiSelectingInjects} setAiSelectingInjects={setAiSelectingInjects} aiFillingEmails={aiFillingEmails} setAiFillingEmails={setAiFillingEmails} handleClose={handleClose} scenarioOverviewData={scenarioOverviewData} setScenarioOverviewData={setScenarioOverviewData} scenarioForm={scenarioForm} setScenarioForm={setScenarioForm} selectedInjects={selectedInjects} setSelectedInjects={setSelectedInjects} scenarioEmails={scenarioEmails} setScenarioEmails={setScenarioEmails} scenarioLoading={scenarioLoading} setScenarioLoading={setScenarioLoading} scenarioStep={scenarioStep} setScenarioStep={setScenarioStep} scenarioTypeAffinity={scenarioTypeAffinity} setScenarioTypeAffinity={setScenarioTypeAffinity} scenarioPlatformsAffinity={scenarioPlatformsAffinity} setScenarioPlatformsAffinity={setScenarioPlatformsAffinity} scenarioInjectSpacing={scenarioInjectSpacing} setScenarioInjectSpacing={setScenarioInjectSpacing} scenarioPlatformSelected={scenarioPlatformSelected} setScenarioPlatformSelected={setScenarioPlatformSelected} scenarioPlatformId={scenarioPlatformId} setScenarioPlatformId={setScenarioPlatformId} scenarioRawAttackPatterns={scenarioRawAttackPatterns} setScenarioRawAttackPatterns={setScenarioRawAttackPatterns} scenarioTargetType={scenarioTargetType} setScenarioTargetType={setScenarioTargetType} scenarioAssets={scenarioAssets} setScenarioAssets={setScenarioAssets} scenarioAssetGroups={scenarioAssetGroups} setScenarioAssetGroups={setScenarioAssetGroups} scenarioTeams={scenarioTeams} setScenarioTeams={setScenarioTeams} scenarioSelectedAsset={scenarioSelectedAsset} setScenarioSelectedAsset={setScenarioSelectedAsset} scenarioSelectedAssetGroup={scenarioSelectedAssetGroup} setScenarioSelectedAssetGroup={setScenarioSelectedAssetGroup} scenarioSelectedTeam={scenarioSelectedTeam} setScenarioSelectedTeam={setScenarioSelectedTeam} scenarioCreating={scenarioCreating} setScenarioCreating={setScenarioCreating} scenarioAIMode={scenarioAIMode} setScenarioAIMode={setScenarioAIMode} scenarioAIGenerating={scenarioAIGenerating} setScenarioAIGenerating={setScenarioAIGenerating} scenarioAINumberOfInjects={scenarioAINumberOfInjects} setScenarioAINumberOfInjects={setScenarioAINumberOfInjects} scenarioAIPayloadAffinity={scenarioAIPayloadAffinity} setScenarioAIPayloadAffinity={setScenarioAIPayloadAffinity} scenarioAITableTopDuration={scenarioAITableTopDuration} setScenarioAITableTopDuration={setScenarioAITableTopDuration} scenarioAIEmailLanguage={scenarioAIEmailLanguage} setScenarioAIEmailLanguage={setScenarioAIEmailLanguage} scenarioAITheme={scenarioAITheme} setScenarioAITheme={setScenarioAITheme} scenarioAIContext={scenarioAIContext} setScenarioAIContext={setScenarioAIContext} scenarioAIGeneratedScenario={scenarioAIGeneratedScenario} setScenarioAIGeneratedScenario={setScenarioAIGeneratedScenario} resetScenarioState={resetScenarioState} />;
       case 'loading': return <CommonLoadingView />;
-      default: return isScanning 
-        ? <CommonLoadingView message="Scanning page..." /> 
+      default: return isScanning
+        ? <CommonLoadingView message="Scanning page..." />
         : <CommonEmptyView logoSuffix={logoSuffix} hasOpenCTI={openctiPlatforms.some(p => p.connected)} hasOpenAEV={openaevPlatforms.some(p => p.connected)} onScan={handleEmptyViewScan} onSearch={handleEmptyViewSearch} onCreateContainer={handleEmptyViewCreateContainer} onInvestigate={handleEmptyViewInvestigate} onAtomicTesting={handleEmptyViewAtomicTesting} onGenerateScenario={handleEmptyViewGenerateScenario} onClearHighlights={handleEmptyViewClearHighlights} isPdfView={isPdfView} />;
     }
   };

--- a/src/panel/App.tsx
+++ b/src/panel/App.tsx
@@ -192,6 +192,7 @@ const App: React.FC = () => {
     updatingContainerId, setUpdatingContainerId,
     updatingContainerDates, setUpdatingContainerDates,
     importResults, setImportResults,
+    containerFailedEntities, setContainerFailedEntities,
     containerWorkflowOrigin, setContainerWorkflowOrigin,
     createIndicators, setCreateIndicators,
     attachPdf, setAttachPdf,
@@ -329,6 +330,7 @@ const App: React.FC = () => {
     setAttachPdf,
     setCreateAsDraft,
     setImportResults,
+    setContainerFailedEntities,
     aiSettings,
     resolvedRelationships,
     setAiGeneratingDescription,
@@ -1661,7 +1663,7 @@ const App: React.FC = () => {
         if (isNonDefaultPlatformEntity) {
           return <OAEVEntityView mode={mode} entity={entity} setEntity={setEntity} entityDetailsLoading={entityDetailsLoading} setEntityDetailsLoading={setEntityDetailsLoading} availablePlatforms={availablePlatforms} multiPlatformResults={multiPlatformResults} setMultiPlatformResults={setMultiPlatformResults} currentPlatformIndex={currentPlatformIndex} setCurrentPlatformIndex={setCurrentPlatformIndex} currentPlatformIndexRef={currentPlatformIndexRef} multiPlatformResultsRef={multiPlatformResultsRef} setPlatformUrl={setPlatformUrl} setSelectedPlatformId={setSelectedPlatformId} entityFromSearchMode={entityFromSearchMode} setEntityFromSearchMode={setEntityFromSearchMode} entityFromScanResults={entityFromScanResults} setEntityFromScanResults={setEntityFromScanResults} setPanelMode={setPanelMode} handleCopyValue={handleCopyValue} />;
         }
-        return <OCTIEntityView mode={mode} entity={entity} setEntity={setEntity} entityContainers={entityContainers} loadingContainers={loadingContainers} entityDetailsLoading={entityDetailsLoading} setEntityDetailsLoading={setEntityDetailsLoading} availablePlatforms={availablePlatforms} multiPlatformResults={multiPlatformResults} setMultiPlatformResults={setMultiPlatformResults} currentPlatformIndex={currentPlatformIndex} setCurrentPlatformIndex={setCurrentPlatformIndex} currentPlatformIndexRef={currentPlatformIndexRef} multiPlatformResultsRef={multiPlatformResultsRef} platformUrl={platformUrl} setPlatformUrl={setPlatformUrl} selectedPlatformId={selectedPlatformId} setSelectedPlatformId={setSelectedPlatformId} entityFromSearchMode={entityFromSearchMode} setEntityFromSearchMode={setEntityFromSearchMode} entityFromScanResults={entityFromScanResults} setEntityFromScanResults={setEntityFromScanResults} setPanelMode={setPanelMode} handleCopyValue={handleCopyValue} handleOpenInPlatform={handleOpenInPlatform} />;
+        return <OCTIEntityView mode={mode} entity={entity} setEntity={setEntity} entityContainers={entityContainers} loadingContainers={loadingContainers} entityDetailsLoading={entityDetailsLoading} setEntityDetailsLoading={setEntityDetailsLoading} availablePlatforms={availablePlatforms} multiPlatformResults={multiPlatformResults} setMultiPlatformResults={setMultiPlatformResults} currentPlatformIndex={currentPlatformIndex} setCurrentPlatformIndex={setCurrentPlatformIndex} currentPlatformIndexRef={currentPlatformIndexRef} multiPlatformResultsRef={multiPlatformResultsRef} platformUrl={platformUrl} setPlatformUrl={setPlatformUrl} selectedPlatformId={selectedPlatformId} setSelectedPlatformId={setSelectedPlatformId} entityFromSearchMode={entityFromSearchMode} setEntityFromSearchMode={setEntityFromSearchMode} entityFromScanResults={entityFromScanResults} setEntityFromScanResults={setEntityFromScanResults} setPanelMode={setPanelMode} handleCopyValue={handleCopyValue} handleOpenInPlatform={handleOpenInPlatform} containerFailedEntities={containerFailedEntities} />;
       }
       case 'not-found': return <CommonNotFoundView entity={entity} mode={mode} entityFromScanResults={entityFromScanResults} setEntityFromScanResults={setEntityFromScanResults} setPanelMode={setPanelMode} setEntitiesToAdd={setEntitiesToAdd} setAddFromNotFound={setAddFromNotFound} />;
       case 'add': return <OCTIAddView setPanelMode={setPanelMode} entitiesToAdd={entitiesToAdd} handleAddEntities={handleAddEntities} submitting={submitting} addFromNotFound={addFromNotFound} setAddFromNotFound={setAddFromNotFound} hasScanResults={scanResultsEntitiesRef.current.length > 0} />;

--- a/src/panel/hooks/useContainerActions.ts
+++ b/src/panel/hooks/useContainerActions.ts
@@ -41,6 +41,9 @@ export interface ContainerActionsProps {
   // Import results
   setImportResults: (results: ImportResults | null) => void;
   
+  // Failed entities
+  setContainerFailedEntities: (entities: Array<{ type: string; value: string; error: string }>) => void;
+
   // AI state
   aiSettings: PanelAIState;
   resolvedRelationships: ResolvedRelationship[];
@@ -95,6 +98,7 @@ export function useContainerActions(props: ContainerActionsProps): ContainerActi
     setAttachPdf,
     setCreateAsDraft,
     setImportResults,
+    setContainerFailedEntities,
     aiSettings,
     resolvedRelationships,
     setAiGeneratingDescription,
@@ -198,6 +202,7 @@ export function useContainerActions(props: ContainerActionsProps): ContainerActi
 
   const handleCreateContainer = useCallback(async () => {
     if (typeof chrome === 'undefined' || !chrome.runtime?.sendMessage) return;
+    setContainerFailedEntities([]);
     setSubmitting(true);
     
     let pdfData: { data: string; filename: string } | null = null;
@@ -298,6 +303,8 @@ export function useContainerActions(props: ContainerActionsProps): ContainerActi
           setSelectedPlatformId(platform.id);
         }
       }
+      const failedEntities: Array<{ type: string; value: string; error: string }> = createdContainer.failedEntities || [];
+      setContainerFailedEntities(failedEntities);
       setEntity({
         id: createdContainer.id,
         entity_type: createdContainer.entity_type || containerType,
@@ -316,8 +323,12 @@ export function useContainerActions(props: ContainerActionsProps): ContainerActi
         _draftId: createdContainer.draftId,
       });
       setEntityContainers([]);
+      if (failedEntities.length > 0) {
+        showToast({ type: 'warning', message: `${containerType} ${updatingContainerId ? 'updated' : 'created'} — ${failedEntities.length} entit${failedEntities.length === 1 ? 'y' : 'ies'} could not be added` });
+      } else {
+        showToast({ type: 'success', message: `${containerType} ${updatingContainerId ? 'updated' : 'created'} successfully` });
+      }
       setPanelMode('entity');
-      showToast({ type: 'success', message: `${containerType} ${updatingContainerId ? 'updated' : 'created'} successfully` });
       setContainerForm({ name: '', description: '', content: '' });
       setEntitiesToAdd([]);
       setContainerWorkflowOrigin(null);
@@ -335,7 +346,7 @@ export function useContainerActions(props: ContainerActionsProps): ContainerActi
     currentPdfFileName, isPdfSource, containerSpecificFields, createAsDraft, updatingContainerId,
     updatingContainerDates, availablePlatforms, setPlatformUrl, setSelectedPlatformId, setEntity,
     setEntityContainers, setPanelMode, showToast, setContainerForm, setEntitiesToAdd, setContainerWorkflowOrigin,
-    setAttachPdf, setCreateAsDraft, setUpdatingContainerId, setUpdatingContainerDates, setSubmitting
+    setAttachPdf, setCreateAsDraft, setUpdatingContainerId, setUpdatingContainerDates, setSubmitting, setContainerFailedEntities
   ]);
 
   return {

--- a/src/panel/hooks/useContainerActions.ts
+++ b/src/panel/hooks/useContainerActions.ts
@@ -6,7 +6,7 @@
 
 import { useCallback } from 'react';
 import type { EntityData, PlatformInfo, ContainerFormState, ContainerSpecificFields, PanelAIState, PanelMode } from '../types/panel-types';
-import type { ImportResults } from '../../shared/types/scan';
+import type { ImportResults, FailedEntityImport } from '../../shared/types/scan';
 import type { ResolvedRelationship } from '../../shared/api/ai/types';
 
 export interface ContainerActionsProps {
@@ -42,7 +42,7 @@ export interface ContainerActionsProps {
   setImportResults: (results: ImportResults | null) => void;
 
   // Failed entities
-  setContainerFailedEntities: (entities: Array<{ type: string; value: string; error: string }>) => void;
+  setContainerFailedEntities: (value: { containerId: string; failed: FailedEntityImport[] } | null) => void;
 
   // AI state
   aiSettings: PanelAIState;
@@ -202,7 +202,7 @@ export function useContainerActions(props: ContainerActionsProps): ContainerActi
 
   const handleCreateContainer = useCallback(async () => {
     if (typeof chrome === 'undefined' || !chrome.runtime?.sendMessage) return;
-    setContainerFailedEntities([]);
+    setContainerFailedEntities(null);
     setSubmitting(true);
 
     let pdfData: { data: string; filename: string } | null = null;
@@ -303,8 +303,10 @@ export function useContainerActions(props: ContainerActionsProps): ContainerActi
           setSelectedPlatformId(platform.id);
         }
       }
-      const failedEntities: Array<{ type: string; value: string; error: string }> = createdContainer.failedEntities || [];
-      setContainerFailedEntities(failedEntities);
+      const failedEntities: FailedEntityImport[] = createdContainer.failedEntities || [];
+      setContainerFailedEntities(
+        failedEntities.length > 0 ? { containerId: createdContainer.id, failed: failedEntities } : null
+      );
       setEntity({
         id: createdContainer.id,
         entity_type: createdContainer.entity_type || containerType,

--- a/src/panel/hooks/useContainerActions.ts
+++ b/src/panel/hooks/useContainerActions.ts
@@ -1,6 +1,6 @@
 /**
  * Container Actions Hook
- * 
+ *
  * Handles container creation, entity addition, and related API calls.
  */
 
@@ -16,7 +16,7 @@ export interface ContainerActionsProps {
   selectedPlatformId: string;
   setPlatformUrl: (url: string) => void;
   setSelectedPlatformId: (id: string) => void;
-  
+
   // Container state
   entitiesToAdd: EntityData[];
   setEntitiesToAdd: React.Dispatch<React.SetStateAction<EntityData[]>>;
@@ -37,10 +37,10 @@ export interface ContainerActionsProps {
   setContainerWorkflowOrigin: (origin: 'preview' | 'direct' | 'import' | null) => void;
   setAttachPdf: (attach: boolean) => void;
   setCreateAsDraft: (draft: boolean) => void;
-  
+
   // Import results
   setImportResults: (results: ImportResults | null) => void;
-  
+
   // Failed entities
   setContainerFailedEntities: (entities: Array<{ type: string; value: string; error: string }>) => void;
 
@@ -48,17 +48,17 @@ export interface ContainerActionsProps {
   aiSettings: PanelAIState;
   resolvedRelationships: ResolvedRelationship[];
   setAiGeneratingDescription: (generating: boolean) => void;
-  
+
   // Entity state
   setEntity: React.Dispatch<React.SetStateAction<EntityData | null>>;
   setEntityContainers: (containers: any[]) => void;
-  
+
   // Page info
   currentPageUrl: string;
   currentPageTitle: string;
   currentPdfFileName: string;
   isPdfSource: boolean;
-  
+
   // UI
   setSubmitting: (submitting: boolean) => void;
   setPanelMode: React.Dispatch<React.SetStateAction<PanelMode>>;
@@ -116,17 +116,17 @@ export function useContainerActions(props: ContainerActionsProps): ContainerActi
   const handleAddEntities = useCallback(async () => {
     if (typeof chrome === 'undefined' || !chrome.runtime?.sendMessage) return;
     setSubmitting(true);
-    
+
     const selectedIsOpenCTI = openctiPlatforms.some(p => p.id === selectedPlatformId);
     const targetPlatformId = selectedIsOpenCTI ? selectedPlatformId : openctiPlatforms[0]?.id;
     const targetPlatform = availablePlatforms.find(p => p.id === targetPlatformId);
-    
+
     if (!targetPlatform) {
       showToast({ type: 'error', message: 'No OpenCTI platform available' });
       setSubmitting(false);
       return;
     }
-    
+
     const response = await chrome.runtime.sendMessage({
       type: 'CREATE_OBSERVABLES_BULK',
       payload: { entities: entitiesToAdd, platformId: targetPlatformId, createIndicator: createIndicators },
@@ -135,29 +135,29 @@ export function useContainerActions(props: ContainerActionsProps): ContainerActi
     if (response?.success && response.data) {
       const createdEntities = response.data as Array<{ id: string; entity_type?: string; observable_value?: string; value?: string; type?: string }>;
       setImportResults({
-        success: true, 
+        success: true,
         total: entitiesToAdd.length,
-        created: createdEntities.map((e, i) => ({ 
-          id: e.id, 
-          type: e.entity_type || e.type || entitiesToAdd[i]?.type || 'unknown', 
-          value: e.observable_value || e.value || entitiesToAdd[i]?.value || entitiesToAdd[i]?.name || 'unknown' 
+        created: createdEntities.map((e, i) => ({
+          id: e.id,
+          type: e.entity_type || e.type || entitiesToAdd[i]?.type || 'unknown',
+          value: e.observable_value || e.value || entitiesToAdd[i]?.value || entitiesToAdd[i]?.name || 'unknown'
         })),
-        failed: [], 
+        failed: [],
         platformName: targetPlatform.name,
         platformUrl: targetPlatform.url,
       });
       setPanelMode('import-results');
       setEntitiesToAdd([]);
     } else {
-      setImportResults({ 
-        success: false, 
-        total: entitiesToAdd.length, 
-        created: [], 
-        failed: entitiesToAdd.map(e => ({ 
-          type: e.type || 'unknown', 
-          value: e.value || e.name || 'unknown', 
-          error: response?.error || 'Failed to create entity' 
-        })), 
+      setImportResults({
+        success: false,
+        total: entitiesToAdd.length,
+        created: [],
+        failed: entitiesToAdd.map(e => ({
+          type: e.type || 'unknown',
+          value: e.value || e.name || 'unknown',
+          error: response?.error || 'Failed to create entity'
+        })),
         platformName: targetPlatform.name,
         platformUrl: targetPlatform.url,
       });
@@ -171,20 +171,20 @@ export function useContainerActions(props: ContainerActionsProps): ContainerActi
     const selectedIsOpenCTI = openctiPlatforms.some(p => p.id === selectedPlatformId);
     const targetPlatformId = selectedIsOpenCTI ? selectedPlatformId : openctiPlatforms[0]?.id;
     const targetPlatform = availablePlatforms.find(p => p.id === targetPlatformId);
-    
+
     if (!aiSettings.available || !targetPlatform?.isEnterprise) return;
-    
+
     setAiGeneratingDescription(true);
     try {
       const response = await chrome.runtime.sendMessage({
         type: 'AI_GENERATE_DESCRIPTION',
-        payload: { 
-          pageTitle: currentPageTitle, 
-          pageUrl: currentPageUrl, 
-          pageContent: containerForm.content || '', 
-          containerType, 
-          containerName: containerForm.name, 
-          detectedEntities: entitiesToAdd.map(e => e.name || e.value).filter(Boolean) 
+        payload: {
+          pageTitle: currentPageTitle,
+          pageUrl: currentPageUrl,
+          pageContent: containerForm.content || '',
+          containerType,
+          containerName: containerForm.name,
+          detectedEntities: entitiesToAdd.map(e => e.name || e.value).filter(Boolean)
         },
       });
       if (response?.success && response.data) {
@@ -204,7 +204,7 @@ export function useContainerActions(props: ContainerActionsProps): ContainerActi
     if (typeof chrome === 'undefined' || !chrome.runtime?.sendMessage) return;
     setContainerFailedEntities([]);
     setSubmitting(true);
-    
+
     let pdfData: { data: string; filename: string } | null = null;
     if (attachPdf) {
       setGeneratingPdf(true);
@@ -218,9 +218,9 @@ export function useContainerActions(props: ContainerActionsProps): ContainerActi
               const base64 = btoa(
                 new Uint8Array(arrayBuffer).reduce((data, byte) => data + String.fromCharCode(byte), '')
               );
-              pdfData = { 
-                data: base64, 
-                filename: currentPdfFileName || 'document.pdf' 
+              pdfData = {
+                data: base64,
+                filename: currentPdfFileName || 'document.pdf'
               };
             }
           } catch {
@@ -242,7 +242,7 @@ export function useContainerActions(props: ContainerActionsProps): ContainerActi
       } catch { /* PDF generation/fetch failed */ }
       setGeneratingPdf(false);
     }
-    
+
     const existingEntitiesWithIndex = entitiesToAdd.map((e, i) => ({ entity: e, originalIndex: i })).filter(({ entity }) => entity.id);
     const entitiesToCreateWithIndex = entitiesToAdd.map((e, i) => ({ entity: e, originalIndex: i })).filter(({ entity }) => !entity.id && (entity.value || entity.observable_value));
     const existingEntityIds = existingEntitiesWithIndex.map(({ entity }) => entity.id as string);
@@ -250,18 +250,18 @@ export function useContainerActions(props: ContainerActionsProps): ContainerActi
       type: entity.type || entity.entity_type || 'Unknown',
       value: entity.value || entity.observable_value || entity.name || '',
     }));
-    
+
     const indexMapping: Record<number, number> = {};
     existingEntitiesWithIndex.forEach(({ originalIndex }, idx) => { indexMapping[originalIndex] = idx; });
     entitiesToCreateWithIndex.forEach(({ originalIndex }, idx) => { indexMapping[originalIndex] = existingEntityIds.length + idx; });
-    
+
     const relationshipsToCreate = resolvedRelationships.map(rel => ({
       fromEntityIndex: indexMapping[rel.fromIndex] ?? -1,
       toEntityIndex: indexMapping[rel.toIndex] ?? -1,
       relationship_type: rel.relationshipType,
       description: rel.reason,
     })).filter(rel => rel.fromEntityIndex >= 0 && rel.toEntityIndex >= 0);
-    
+
     const response = await chrome.runtime.sendMessage({
       type: 'CREATE_CONTAINER',
       payload: {
@@ -355,4 +355,3 @@ export function useContainerActions(props: ContainerActionsProps): ContainerActi
     handleGenerateAIDescription,
   };
 }
-

--- a/src/panel/hooks/useContainerState.ts
+++ b/src/panel/hooks/useContainerState.ts
@@ -1,6 +1,6 @@
 /**
  * Container State Hook
- * 
+ *
  * Manages all container-related state for the panel.
  */
 
@@ -23,13 +23,13 @@ export interface ContainerStateReturn {
   setOCTIContainerType: (type: string) => void;
   containerForm: ContainerFormState;
   setContainerForm: React.Dispatch<React.SetStateAction<ContainerFormState>>;
-  
+
   // Entity containers
   entityContainers: ContainerData[];
   setEntityContainers: (containers: ContainerData[]) => void;
   loadingContainers: boolean;
   setLoadingContainers: (loading: boolean) => void;
-  
+
   // Labels and markings
   selectedLabels: LabelOption[];
   setSelectedLabels: (labels: LabelOption[]) => void;
@@ -39,23 +39,23 @@ export interface ContainerStateReturn {
   setAvailableLabels: (labels: LabelOption[]) => void;
   availableMarkings: MarkingOption[];
   setAvailableMarkings: (markings: MarkingOption[]) => void;
-  
+
   // Entities to add
   entitiesToAdd: EntityData[];
   setEntitiesToAdd: React.Dispatch<React.SetStateAction<EntityData[]>>;
-  
+
   // Track if add was triggered from not-found view (for back navigation)
   addFromNotFound: boolean;
   setAddFromNotFound: (fromNotFound: boolean) => void;
-  
+
   // Form submission
   submitting: boolean;
   setSubmitting: (submitting: boolean) => void;
-  
+
   // Container-specific fields
   containerSpecificFields: ContainerSpecificFields;
   setContainerSpecificFields: React.Dispatch<React.SetStateAction<ContainerSpecificFields>>;
-  
+
   // Available vocabulary options
   availableReportTypes: VocabularyOption[];
   setAvailableReportTypes: (types: VocabularyOption[]) => void;
@@ -69,7 +69,7 @@ export interface ContainerStateReturn {
   setAvailableResponseTypes: (types: VocabularyOption[]) => void;
   availableAuthors: AuthorOption[];
   setAvailableAuthors: (authors: AuthorOption[]) => void;
-  
+
   // Existing containers (for upsert)
   existingContainers: ContainerData[];
   setExistingContainers: (containers: ContainerData[]) => void;
@@ -79,7 +79,7 @@ export interface ContainerStateReturn {
   setUpdatingContainerId: (id: string | null) => void;
   updatingContainerDates: { published?: string; created?: string } | null;
   setUpdatingContainerDates: (dates: { published?: string; created?: string } | null) => void;
-  
+
   // Import results
   importResults: ImportResults | null;
   setImportResults: (results: ImportResults | null) => void;
@@ -87,11 +87,11 @@ export interface ContainerStateReturn {
   // Failed entities from last container creation
   containerFailedEntities: Array<{ type: string; value: string; error: string }>;
   setContainerFailedEntities: (entities: Array<{ type: string; value: string; error: string }>) => void;
-  
+
   // Container workflow
   containerWorkflowOrigin: 'preview' | 'direct' | 'import' | null;
   setContainerWorkflowOrigin: (origin: 'preview' | 'direct' | 'import' | null) => void;
-  
+
   // PDF and indicators options
   createIndicators: boolean;
   setCreateIndicators: (create: boolean) => void;
@@ -101,7 +101,7 @@ export interface ContainerStateReturn {
   setGeneratingPdf: (generating: boolean) => void;
   createAsDraft: boolean;
   setCreateAsDraft: (draft: boolean) => void;
-  
+
   // Labels/markings loaded state
   labelsLoaded: boolean;
   setLabelsLoaded: (loaded: boolean) => void;
@@ -120,26 +120,26 @@ export function useContainerState(): ContainerStateReturn {
     description: '',
     content: '',
   });
-  
+
   // Entity containers
   const [entityContainers, setEntityContainers] = useState<ContainerData[]>([]);
   const [loadingContainers, setLoadingContainers] = useState(false);
-  
+
   // Labels and markings
   const [selectedLabels, setSelectedLabels] = useState<LabelOption[]>([]);
   const [selectedMarkings, setSelectedMarkings] = useState<MarkingOption[]>([]);
   const [availableLabels, setAvailableLabels] = useState<LabelOption[]>([]);
   const [availableMarkings, setAvailableMarkings] = useState<MarkingOption[]>([]);
-  
+
   // Entities to add
   const [entitiesToAdd, setEntitiesToAdd] = useState<EntityData[]>([]);
-  
+
   // Track if add was triggered from not-found view
   const [addFromNotFound, setAddFromNotFound] = useState(false);
-  
+
   // Form submission
   const [submitting, setSubmitting] = useState(false);
-  
+
   // Container-specific fields
   const [containerSpecificFields, setContainerSpecificFields] = useState<ContainerSpecificFields>({
     report_types: [],
@@ -149,7 +149,7 @@ export function useContainerState(): ContainerStateReturn {
     response_types: [],
     createdBy: '',
   });
-  
+
   // Available vocabulary options
   const [availableReportTypes, setAvailableReportTypes] = useState<VocabularyOption[]>([]);
   const [availableContexts, setAvailableContexts] = useState<VocabularyOption[]>([]);
@@ -157,7 +157,7 @@ export function useContainerState(): ContainerStateReturn {
   const [availablePriorities, setAvailablePriorities] = useState<VocabularyOption[]>([]);
   const [availableResponseTypes, setAvailableResponseTypes] = useState<VocabularyOption[]>([]);
   const [availableAuthors, setAvailableAuthors] = useState<AuthorOption[]>([]);
-  
+
   // Existing containers (for upsert)
   const [existingContainers, setExistingContainers] = useState<ContainerData[]>([]);
   const [checkingExisting, setCheckingExisting] = useState(false);
@@ -166,26 +166,26 @@ export function useContainerState(): ContainerStateReturn {
     published?: string;
     created?: string;
   } | null>(null);
-  
+
   // Import results
   const [importResults, setImportResults] = useState<ImportResults | null>(null);
 
   // Failed entities from last container creation
   const [containerFailedEntities, setContainerFailedEntities] = useState<Array<{ type: string; value: string; error: string }>>([]);
-  
+
   // Container workflow
   const [containerWorkflowOrigin, setContainerWorkflowOrigin] = useState<'preview' | 'direct' | 'import' | null>(null);
-  
+
   // PDF and indicators options
   const [createIndicators, setCreateIndicators] = useState(true);
   const [attachPdf, setAttachPdf] = useState(true);
   const [generatingPdf, setGeneratingPdf] = useState(false);
   const [createAsDraft, setCreateAsDraft] = useState(false);
-  
+
   // Labels/markings loaded state
   const [labelsLoaded, setLabelsLoaded] = useState(false);
   const [markingsLoaded, setMarkingsLoaded] = useState(false);
-  
+
   return {
     containerType,
     setOCTIContainerType,
@@ -251,4 +251,3 @@ export function useContainerState(): ContainerStateReturn {
     setMarkingsLoaded,
   };
 }
-

--- a/src/panel/hooks/useContainerState.ts
+++ b/src/panel/hooks/useContainerState.ts
@@ -83,6 +83,10 @@ export interface ContainerStateReturn {
   // Import results
   importResults: ImportResults | null;
   setImportResults: (results: ImportResults | null) => void;
+
+  // Failed entities from last container creation
+  containerFailedEntities: Array<{ type: string; value: string; error: string }>;
+  setContainerFailedEntities: (entities: Array<{ type: string; value: string; error: string }>) => void;
   
   // Container workflow
   containerWorkflowOrigin: 'preview' | 'direct' | 'import' | null;
@@ -165,6 +169,9 @@ export function useContainerState(): ContainerStateReturn {
   
   // Import results
   const [importResults, setImportResults] = useState<ImportResults | null>(null);
+
+  // Failed entities from last container creation
+  const [containerFailedEntities, setContainerFailedEntities] = useState<Array<{ type: string; value: string; error: string }>>([]);
   
   // Container workflow
   const [containerWorkflowOrigin, setContainerWorkflowOrigin] = useState<'preview' | 'direct' | 'import' | null>(null);
@@ -226,6 +233,8 @@ export function useContainerState(): ContainerStateReturn {
     setUpdatingContainerDates,
     importResults,
     setImportResults,
+    containerFailedEntities,
+    setContainerFailedEntities,
     containerWorkflowOrigin,
     setContainerWorkflowOrigin,
     createIndicators,

--- a/src/panel/hooks/useContainerState.ts
+++ b/src/panel/hooks/useContainerState.ts
@@ -15,7 +15,7 @@ import type {
   VocabularyOption,
   AuthorOption,
 } from '../types/panel-types';
-import type { ImportResults } from '../../shared/types/scan';
+import type { ImportResults, FailedEntityImport } from '../../shared/types/scan';
 
 export interface ContainerStateReturn {
   // Container type and form
@@ -84,9 +84,9 @@ export interface ContainerStateReturn {
   importResults: ImportResults | null;
   setImportResults: (results: ImportResults | null) => void;
 
-  // Failed entities from last container creation
-  containerFailedEntities: Array<{ type: string; value: string; error: string }>;
-  setContainerFailedEntities: (entities: Array<{ type: string; value: string; error: string }>) => void;
+  // Failed entities from last container creation, scoped to the container that was created
+  containerFailedEntities: { containerId: string; failed: FailedEntityImport[] } | null;
+  setContainerFailedEntities: (value: { containerId: string; failed: FailedEntityImport[] } | null) => void;
 
   // Container workflow
   containerWorkflowOrigin: 'preview' | 'direct' | 'import' | null;
@@ -170,8 +170,8 @@ export function useContainerState(): ContainerStateReturn {
   // Import results
   const [importResults, setImportResults] = useState<ImportResults | null>(null);
 
-  // Failed entities from last container creation
-  const [containerFailedEntities, setContainerFailedEntities] = useState<Array<{ type: string; value: string; error: string }>>([]);
+  // Failed entities from last container creation, scoped to the container that was created
+  const [containerFailedEntities, setContainerFailedEntities] = useState<{ containerId: string; failed: FailedEntityImport[] } | null>(null);
 
   // Container workflow
   const [containerWorkflowOrigin, setContainerWorkflowOrigin] = useState<'preview' | 'direct' | 'import' | null>(null);

--- a/src/panel/types/view-props.ts
+++ b/src/panel/types/view-props.ts
@@ -1,6 +1,6 @@
 /**
  * Panel View Props
- * 
+ *
  * Common prop interfaces shared across panel views.
  * This allows views to be extracted into separate components while maintaining
  * type safety and consistent state management.
@@ -530,4 +530,3 @@ export interface PreviewViewProps extends BaseViewProps, PlatformViewProps {
   /** Set submitting state */
   setSubmitting: (submitting: boolean) => void;
 }
-

--- a/src/panel/types/view-props.ts
+++ b/src/panel/types/view-props.ts
@@ -126,6 +126,8 @@ export interface OCTIEntityViewProps {
   handleCopyValue: (value: string) => void;
   /** Open entity in platform */
   handleOpenInPlatform: (entityId: string, draftId?: string) => void;
+  /** Entities that failed to be created during the last container import */
+  containerFailedEntities?: Array<{ type: string; value: string; error: string }>;
 }
 
 /**

--- a/src/panel/types/view-props.ts
+++ b/src/panel/types/view-props.ts
@@ -25,7 +25,7 @@ import type {
   VocabularyOption,
   AuthorOption,
 } from './panel-types';
-import type { ScanResultEntity, ImportResults } from '../../shared/types/scan';
+import type { ScanResultEntity, ImportResults, FailedEntityImport } from '../../shared/types/scan';
 import type { ResolvedRelationship, GeneratedAtomicTest } from '../../shared/api/ai/types';
 import type {
   OAEVAsset,
@@ -126,8 +126,8 @@ export interface OCTIEntityViewProps {
   handleCopyValue: (value: string) => void;
   /** Open entity in platform */
   handleOpenInPlatform: (entityId: string, draftId?: string) => void;
-  /** Entities that failed to be created during the last container import */
-  containerFailedEntities?: Array<{ type: string; value: string; error: string }>;
+  /** Entities that failed to be created during the last container import, scoped to the created container */
+  containerFailedEntities?: { containerId: string; failed: FailedEntityImport[] } | null;
 }
 
 /**

--- a/src/panel/views/OCTIEntityView.tsx
+++ b/src/panel/views/OCTIEntityView.tsx
@@ -68,6 +68,7 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
   setPanelMode,
   handleCopyValue,
   handleOpenInPlatform,
+  containerFailedEntities,
 }) => {
   const logoSuffix = useLogoSuffix(mode);
   const contentTextStyle = useContentTextStyle(mode);
@@ -805,6 +806,40 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
           <Typography variant="caption" sx={{ color: 'text.secondary' }}>
             Loading containers...
           </Typography>
+        </Box>
+      )}
+
+      {/* Failed entity imports warning */}
+      {containerFailedEntities && containerFailedEntities.length > 0 && (
+        <Box sx={{ mb: 2.5, border: 1, borderColor: 'warning.main', borderRadius: 1, overflow: 'hidden' }}>
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1.5, py: 1, bgcolor: 'warning.main' }}>
+            <WarningAmberOutlined sx={{ fontSize: 16, color: 'white' }} />
+            <Typography variant="caption" sx={{ fontWeight: 700, color: 'white', textTransform: 'uppercase', letterSpacing: 0.5 }}>
+              {containerFailedEntities.length} entit{containerFailedEntities.length === 1 ? 'y' : 'ies'} could not be added
+            </Typography>
+          </Box>
+          <Box sx={{ maxHeight: 150, overflow: 'auto' }}>
+            {containerFailedEntities.map((e, idx) => (
+              <Box
+                key={idx}
+                sx={{
+                  display: 'flex',
+                  alignItems: 'flex-start',
+                  gap: 1,
+                  px: 1.5,
+                  py: 1,
+                  borderTop: 1,
+                  borderColor: 'divider',
+                }}
+              >
+                <ItemIcon type={e.type} size="small" color={itemColor(e.type, mode === 'dark')} />
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography variant="body2" sx={{ fontWeight: 500, wordBreak: 'break-all' }}>{e.value}</Typography>
+                  <Typography variant="caption" sx={{ color: 'error.main' }}>{e.error}</Typography>
+                </Box>
+              </Box>
+            ))}
+          </Box>
         </Box>
       )}
 

--- a/src/panel/views/OCTIEntityView.tsx
+++ b/src/panel/views/OCTIEntityView.tsx
@@ -809,17 +809,17 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
         </Box>
       )}
 
-      {/* Failed entity imports warning */}
-      {containerFailedEntities && containerFailedEntities.length > 0 && (
+      {/* Failed entity imports warning — only shown for the container that was just created */}
+      {containerFailedEntities && entity?.id === containerFailedEntities.containerId && containerFailedEntities.failed.length > 0 && (
         <Box sx={{ mb: 2.5, border: 1, borderColor: 'warning.main', borderRadius: 1, overflow: 'hidden' }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, px: 1.5, py: 1, bgcolor: 'warning.main' }}>
             <WarningAmberOutlined sx={{ fontSize: 16, color: 'white' }} />
             <Typography variant="caption" sx={{ fontWeight: 700, color: 'white', textTransform: 'uppercase', letterSpacing: 0.5 }}>
-              {containerFailedEntities.length} entit{containerFailedEntities.length === 1 ? 'y' : 'ies'} could not be added
+              {containerFailedEntities.failed.length} entit{containerFailedEntities.failed.length === 1 ? 'y' : 'ies'} could not be added
             </Typography>
           </Box>
           <Box sx={{ maxHeight: 150, overflow: 'auto' }}>
-            {containerFailedEntities.map((e, idx) => (
+            {containerFailedEntities.failed.map((e, idx) => (
               <Box
                 key={idx}
                 sx={{
@@ -835,7 +835,9 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
                 <ItemIcon type={e.type} size="small" color={itemColor(e.type, mode === 'dark')} />
                 <Box sx={{ flex: 1, minWidth: 0 }}>
                   <Typography variant="body2" sx={{ fontWeight: 500, wordBreak: 'break-all' }}>{e.value}</Typography>
-                  <Typography variant="caption" sx={{ color: 'error.main' }}>{e.error}</Typography>
+                  {e.error && (
+                    <Typography variant="caption" sx={{ color: 'error.main' }}>{e.error}</Typography>
+                  )}
                 </Box>
               </Box>
             ))}

--- a/src/panel/views/OCTIEntityView.tsx
+++ b/src/panel/views/OCTIEntityView.tsx
@@ -1,6 +1,6 @@
 /**
  * OCTIEntityView - Displays entity details for OpenCTI entities
- * 
+ *
  * Handles rendering of both entities and observables with proper styling,
  * platform navigation for multi-platform results, and action buttons.
  */
@@ -27,8 +27,8 @@ import {
 } from '@mui/icons-material';
 import Markdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
-import { 
-  inferPlatformTypeFromEntityType, 
+import {
+  inferPlatformTypeFromEntityType,
   getPlatformLogoName,
   getPlatformName,
   parsePrefixedType,
@@ -78,9 +78,9 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
     const platformType = targetEntity.platformType || inferPlatformTypeFromEntityType(targetEntity.type);
     const entityIdToFetch = targetEntity.entityId || targetEntity.id;
     const entityTypeToFetch = (targetEntity.entity_type || targetEntity.type || '').replace(/^(oaev|ogrc)-/, '');
-    
+
     if (!entityIdToFetch || typeof chrome === 'undefined' || !chrome.runtime?.sendMessage) return;
-    
+
     setEntityDetailsLoading(true);
     chrome.runtime.sendMessage({
       type: 'GET_ENTITY_DETAILS',
@@ -94,7 +94,7 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
         setEntityDetailsLoading(false);
         return;
       }
-      
+
       if (response?.success && response.data) {
         const fullEntity = {
           ...targetEntity,
@@ -153,31 +153,31 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
 
   // Check if this is a non-default platform entity (any platform other than OpenCTI)
   const entityType = (entity as any).type || '';
-  const isNonDefaultPlatformEntity = (entity as any).isNonDefaultPlatform || 
+  const isNonDefaultPlatformEntity = (entity as any).isNonDefaultPlatform ||
     (entity as any).platformType !== 'opencti' ||
     parsePrefixedType(entityType) !== null;
-  
+
   // If non-default platform entity, this component shouldn't render it
   // (App.tsx handles routing to OAEVEntityView)
   if (isNonDefaultPlatformEntity) {
     return null;
   }
-  
+
   // Entity might be a DetectedOCTIEntity/DetectedObservable with entityData, or direct entity data
   const entityData = (entity as any).entityData || entity || {};
   const entityId = (entity as any).entityId || entityData?.id || entity?.id;
   const entityPlatformId = (entity as any).platformId;
-  
+
   const type = entityData.entity_type || entity.type || 'unknown';
   const color = itemColor(type, mode === 'dark');
   const name = entityData.representative?.main || entityData.name || entity.value || entity.name || 'Unknown';
   const rawDescription = entityData.description || entity.description || '';
   // Truncate description to 500 characters
-  const description = rawDescription.length > 500 
-    ? rawDescription.slice(0, 500) + '...' 
+  const description = rawDescription.length > 500
+    ? rawDescription.slice(0, 500) + '...'
     : rawDescription;
   const aliases = entityData.aliases || entity.aliases;
-  
+
   // Attack Pattern specific: x_mitre_id
   const xMitreId = entityData.x_mitre_id || entity.x_mitre_id;
   const isAttackPattern = type.toLowerCase() === 'attack-pattern';
@@ -185,26 +185,26 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
   const objectMarking = entityData.objectMarking || entity.objectMarking;
   const created = entityData.created || entity.created;
   const modified = entityData.modified || entity.modified;
-  
+
   // Author and creators
   const author = entityData.createdBy || entity.createdBy;
   const creators = entityData.creators || entity.creators;
-  
+
   // Get current platform info
-  const currentPlatform = entityPlatformId 
+  const currentPlatform = entityPlatformId
     ? availablePlatforms.find(p => p.id === entityPlatformId)
     : availablePlatforms[0];
-  
+
   // Determine if this is an observable or SDO
   const observableTypes = ['IPv4-Addr', 'IPv6-Addr', 'Domain-Name', 'Hostname', 'Url', 'Email-Addr', 'Mac-Addr', 'StixFile', 'Artifact', 'Cryptocurrency-Wallet', 'User-Agent', 'Phone-Number', 'Bank-Account'];
-  const isObservable = observableTypes.some(t => type.toLowerCase().includes(t.toLowerCase().replace(/-/g, ''))) || 
+  const isObservable = observableTypes.some(t => type.toLowerCase().includes(t.toLowerCase().replace(/-/g, ''))) ||
                        type.includes('Addr') || type.includes('Observable');
   const isIndicator = type.toLowerCase() === 'indicator';
-  
+
   // Confidence is for SDOs (not observables or indicators), Score is for observables and indicators
   const confidence = (!isObservable && !isIndicator) ? (entityData.confidence ?? entity.confidence) : undefined;
   const score = (isObservable || isIndicator) ? (entityData.x_opencti_score ?? entity.x_opencti_score) : undefined;
-  
+
   // CVSS fields for vulnerabilities
   const cvssScore = entityData.x_opencti_cvss_base_score;
   const cvssSeverity = entityData.x_opencti_cvss_base_severity;
@@ -227,7 +227,7 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
           size="small"
           startIcon={<ChevronLeftOutlined />}
           onClick={entityFromSearchMode || entityFromScanResults ? handleBackToList : () => setPanelMode('empty')}
-          sx={{ 
+          sx={{
             color: 'text.secondary',
             textTransform: 'none',
             '&:hover': { bgcolor: 'action.hover' },
@@ -236,16 +236,16 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
           {entityFromScanResults ? 'Back to scan results' : entityFromSearchMode ? 'Back to search' : 'Back to actions'}
         </Button>
       </Box>
-      
+
       {/* Platform indicator bar */}
       {(availablePlatforms.length > 1 || hasMultiplePlatforms) && (
-        <Box 
-          sx={{ 
-            display: 'flex', 
-            alignItems: 'center', 
+        <Box
+          sx={{
+            display: 'flex',
+            alignItems: 'center',
             justifyContent: 'space-between',
-            mb: 2, 
-            p: 1, 
+            mb: 2,
+            p: 1,
             bgcolor: 'action.hover',
             borderRadius: 1,
             border: 1,
@@ -254,9 +254,9 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
         >
           {hasMultiplePlatforms ? (
             <>
-              <IconButton 
-                size="small" 
-                onClick={handlePrevPlatform} 
+              <IconButton
+                size="small"
+                onClick={handlePrevPlatform}
                 disabled={currentPlatformIndex === 0 || entityDetailsLoading}
                 sx={{ opacity: currentPlatformIndex === 0 ? 0.3 : 1 }}
               >
@@ -267,7 +267,7 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
                   <CircularProgress size={18} />
                 ) : (
                   <img
-                    src={typeof chrome !== 'undefined' && chrome.runtime?.getURL 
+                    src={typeof chrome !== 'undefined' && chrome.runtime?.getURL
                       ? chrome.runtime.getURL(`assets/logos/logo_${platformLogo}_${logoSuffix}_embleme_square.svg`)
                       : `../assets/logos/logo_${platformLogo}_${logoSuffix}_embleme_square.svg`
                     }
@@ -283,9 +283,9 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
                   ({currentPlatformIndex + 1}/{multiPlatformResults.length})
                 </Typography>
               </Box>
-              <IconButton 
-                size="small" 
-                onClick={handleNextPlatform} 
+              <IconButton
+                size="small"
+                onClick={handleNextPlatform}
                 disabled={currentPlatformIndex === multiPlatformResults.length - 1 || entityDetailsLoading}
                 sx={{ opacity: currentPlatformIndex === multiPlatformResults.length - 1 ? 0.3 : 1 }}
               >
@@ -298,7 +298,7 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
                 <CircularProgress size={18} />
               ) : (
                 <img
-                  src={typeof chrome !== 'undefined' && chrome.runtime?.getURL 
+                  src={typeof chrome !== 'undefined' && chrome.runtime?.getURL
                     ? chrome.runtime.getURL(`assets/logos/logo_${platformLogo}_${logoSuffix}_embleme_square.svg`)
                     : `../assets/logos/logo_${platformLogo}_${logoSuffix}_embleme_square.svg`
                   }
@@ -341,16 +341,16 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
           {name}
         </Typography>
         {(entity as any)?._draftId && (
-          <Chip 
-            label="Draft" 
-            size="small" 
-            sx={{ 
-              bgcolor: '#ff9800', 
-              color: '#000', 
+          <Chip
+            label="Draft"
+            size="small"
+            sx={{
+              bgcolor: '#ff9800',
+              color: '#000',
               fontWeight: 700,
               fontSize: '0.7rem',
               height: 20,
-            }} 
+            }}
           />
         )}
       </Box>
@@ -361,16 +361,16 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
           <Typography variant="caption" sx={sectionTitleStyle}>
             Technique ID
           </Typography>
-          <Chip 
-            label={xMitreId} 
-            size="small" 
-            sx={{ 
-              bgcolor: hexToRGB(color, 0.2), 
+          <Chip
+            label={xMitreId}
+            size="small"
+            sx={{
+              bgcolor: hexToRGB(color, 0.2),
               color,
               fontWeight: 600,
               borderRadius: 1,
               fontSize: '0.875rem',
-            }} 
+            }}
           />
         </Box>
       )}
@@ -448,9 +448,9 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
           <Typography variant="caption" sx={sectionTitleStyle}>
             Description
           </Typography>
-          <Box sx={{ 
-            ...contentTextStyle, 
-            '& p': { my: 0.5 }, 
+          <Box sx={{
+            ...contentTextStyle,
+            '& p': { my: 0.5 },
             '& ul, & ol': { pl: 2, my: 0.5 },
             '& a': { color: 'primary.main' },
           }}>
@@ -469,17 +469,17 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
           </Typography>
           <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 0.75 }}>
             {aliases.slice(0, 8).map((alias: string, i: number) => (
-              <Chip 
-                key={i} 
-                label={alias} 
-                size="small" 
-                sx={{ borderRadius: 1, bgcolor: 'action.selected', fontWeight: 500 }} 
+              <Chip
+                key={i}
+                label={alias}
+                size="small"
+                sx={{ borderRadius: 1, bgcolor: 'action.selected', fontWeight: 500 }}
               />
             ))}
             {aliases.length > 8 && (
-              <Chip 
-                label={`+${aliases.length - 8}`} 
-                size="small" 
+              <Chip
+                label={`+${aliases.length - 8}`}
+                size="small"
                 sx={{ bgcolor: 'action.hover', fontWeight: 600 }}
               />
             )}
@@ -496,11 +496,11 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
                 Author
               </Typography>
               {author.id && currentPlatform?.url ? (
-                <Typography 
-                  variant="body2" 
+                <Typography
+                  variant="body2"
                   onClick={() => handleOpenInPlatform(author.id)}
-                  sx={{ 
-                    fontWeight: 500, 
+                  sx={{
+                    fontWeight: 500,
                     ...contentTextStyle,
                     color: 'primary.main',
                     cursor: 'pointer',
@@ -606,15 +606,15 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
                 label={label.value}
                 size="small"
                 variant="outlined"
-                sx={{ 
+                sx={{
                   color: label.color,
                   borderColor: label.color,
                   bgcolor: hexToRGB(label.color, 0.08),
                   fontWeight: 500,
                   borderRadius: 1,
                   maxWidth: 150,
-                  '& .MuiChip-label': { 
-                    overflow: 'hidden', 
+                  '& .MuiChip-label': {
+                    overflow: 'hidden',
                     textOverflow: 'ellipsis',
                     whiteSpace: 'nowrap',
                   },
@@ -635,10 +635,10 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
             {objectMarking.map((marking: any, i: number) => {
               const markingColor = marking.x_opencti_color || getMarkingColor(marking.definition, mode);
               return (
-                <Chip 
-                  key={i} 
-                  label={marking.definition} 
-                  size="small" 
+                <Chip
+                  key={i}
+                  label={marking.definition}
+                  size="small"
                   sx={{
                     borderRadius: 1,
                     fontWeight: 600,
@@ -648,8 +648,8 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
                     color: mode === 'dark' ? '#ffffff' : 'text.primary',
                     border: `2px solid ${markingColor}`,
                     maxWidth: 150,
-                    '& .MuiChip-label': { 
-                      overflow: 'hidden', 
+                    '& .MuiChip-label': {
+                      overflow: 'hidden',
                       textOverflow: 'ellipsis',
                       whiteSpace: 'nowrap',
                     },
@@ -663,12 +663,12 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
 
       {/* Dates Section */}
       {(created || modified || entityData.created_at || entityData.updated_at || entityData.first_seen || entityData.last_seen) && (
-        <Paper 
-          elevation={0} 
-          sx={{ 
-            mb: 2.5, 
-            p: 2, 
-            borderRadius: 1, 
+        <Paper
+          elevation={0}
+          sx={{
+            mb: 2.5,
+            p: 2,
+            borderRadius: 1,
             bgcolor: mode === 'dark' ? 'rgba(255,255,255,0.03)' : 'rgba(0,0,0,0.02)',
             border: 1,
             borderColor: 'divider',
@@ -769,10 +769,10 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
                 >
                   <ItemIcon type={container.entity_type} size="small" color={containerColor} />
                   <Box sx={{ flex: 1, minWidth: 0 }}>
-                    <Typography 
-                      variant="body2" 
-                      sx={{ 
-                        fontWeight: 500, 
+                    <Typography
+                      variant="body2"
+                      sx={{
+                        fontWeight: 500,
                         whiteSpace: 'nowrap',
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',
@@ -852,17 +852,17 @@ export const OCTIEntityView: React.FC<OCTIEntityViewProps> = ({
             variant="contained"
             size="small"
             startIcon={
-              <img 
-                src={typeof chrome !== 'undefined' && chrome.runtime?.getURL 
+              <img
+                src={typeof chrome !== 'undefined' && chrome.runtime?.getURL
                   ? chrome.runtime.getURL(`assets/logos/logo_opencti_${mode === 'dark' ? 'light' : 'dark'}-theme_embleme_square.svg`)
                   : `../assets/logos/logo_opencti_${mode === 'dark' ? 'light' : 'dark'}-theme_embleme_square.svg`
-                } 
-                alt="" 
-                style={{ width: 18, height: 18 }} 
+                }
+                alt=""
+                style={{ width: 18, height: 18 }}
               />
             }
             onClick={() => {
-              const url = (entity as any)?._draftId 
+              const url = (entity as any)?._draftId
                 ? `${currentPlatform.url}/dashboard/data/import/draft/${(entity as any)?._draftId}`
                 : `${currentPlatform.url}/dashboard/id/${entityId}`;
               window.open(url, '_blank');

--- a/src/panel/views/OCTIImportResultsView.tsx
+++ b/src/panel/views/OCTIImportResultsView.tsx
@@ -18,6 +18,7 @@ import {
   ErrorOutline,
   OpenInNewOutlined,
   ChevronLeftOutlined,
+  WarningAmberOutlined,
 } from '@mui/icons-material';
 import ItemIcon from '../../shared/components/ItemIcon';
 import { itemColor, hexToRGB } from '../../shared/theme/colors';
@@ -59,6 +60,8 @@ export const OCTIImportResultsView: React.FC<ImportResultsViewProps> = ({
 
   if (!importResults) return null;
 
+  const partialSuccess = importResults.success && importResults.failed.length > 0;
+
   return (
     <Box sx={{ p: 2 }}>
       {/* Success/Error header */}
@@ -70,23 +73,27 @@ export const OCTIImportResultsView: React.FC<ImportResultsViewProps> = ({
           textAlign: 'center',
           mb: 2,
           p: 3,
-          bgcolor: importResults.success ? 'success.main' : 'error.main',
+          bgcolor: partialSuccess ? 'warning.main' : importResults.success ? 'success.main' : 'error.main',
           borderRadius: 2,
           color: 'white',
         }}
       >
-        {importResults.success ? (
+        {partialSuccess ? (
+          <WarningAmberOutlined sx={{ fontSize: 48, mb: 1 }} />
+        ) : importResults.success ? (
           <CheckCircleOutlined sx={{ fontSize: 48, mb: 1 }} />
         ) : (
           <ErrorOutline sx={{ fontSize: 48, mb: 1 }} />
         )}
         <Typography variant="h5" sx={{ fontWeight: 600, mb: 0.5 }}>
-          {importResults.success ? 'Import Successful!' : 'Import Failed'}
+          {partialSuccess ? 'Partial Import' : importResults.success ? 'Import Successful!' : 'Import Failed'}
         </Typography>
         <Typography variant="body2" sx={{ opacity: 0.9 }}>
-          {importResults.success
-            ? `${importResults.created.length} entit${importResults.created.length === 1 ? 'y' : 'ies'} created in ${importResults.platformName}`
-            : `Failed to create ${importResults.failed.length} entit${importResults.failed.length === 1 ? 'y' : 'ies'}`
+          {partialSuccess
+            ? `${importResults.created.length} created, ${importResults.failed.length} entit${importResults.failed.length === 1 ? 'y' : 'ies'} could not be added`
+            : importResults.success
+              ? `${importResults.created.length} entit${importResults.created.length === 1 ? 'y' : 'ies'} created in ${importResults.platformName}`
+              : `Failed to create ${importResults.failed.length} entit${importResults.failed.length === 1 ? 'y' : 'ies'}`
           }
         </Typography>
       </Box>

--- a/src/panel/views/OCTIImportResultsView.tsx
+++ b/src/panel/views/OCTIImportResultsView.tsx
@@ -298,7 +298,7 @@ export const OCTIImportResultsView: React.FC<ImportResultsViewProps> = ({
           <Typography variant="subtitle2" sx={{ mb: 1.5, color: 'error.main', fontWeight: 600 }}>
             FAILED ({importResults.failed.length})
           </Typography>
-          <Box sx={{ maxHeight: 150, overflow: 'auto', border: 1, borderColor: 'error.main', borderRadius: 1, bgcolor: 'error.dark', opacity: 0.1 }}>
+          <Box sx={{ maxHeight: 150, overflow: 'auto', border: 1, borderColor: 'error.main', borderRadius: 1, bgcolor: 'error.dark', opacity: 0.5 }}>
             {importResults.failed.map((entity, idx) => (
               <Box
                 key={idx}
@@ -313,11 +313,11 @@ export const OCTIImportResultsView: React.FC<ImportResultsViewProps> = ({
               >
                 <ItemIcon type={entity.type} size="small" />
                 <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Typography variant="body2" sx={{ fontWeight: 500, wordBreak: 'break-word' }}>
+                  <Typography variant="body1" sx={{ fontWeight: 500, wordBreak: 'break-word' }}>
                     {entity.value}
                   </Typography>
                   {entity.error && (
-                    <Typography variant="caption" sx={{ color: 'error.main' }}>
+                    <Typography variant="caption">
                       {entity.error}
                     </Typography>
                   )}

--- a/src/panel/views/OCTIImportResultsView.tsx
+++ b/src/panel/views/OCTIImportResultsView.tsx
@@ -225,16 +225,16 @@ export const OCTIImportResultsView: React.FC<ImportResultsViewProps> = ({
             {importResults.created.map((entity, idx) => {
               const color = itemColor(entity.type, mode === 'dark');
               // Construct the OpenCTI URL for the entity
-              const entityUrl = importResults.platformUrl 
+              const entityUrl = importResults.platformUrl
                 ? `${importResults.platformUrl.replace(/\/$/, '')}/dashboard/id/${entity.id}`
                 : null;
-              
+
               const handleOpenEntity = () => {
                 if (entityUrl) {
                   window.open(entityUrl, '_blank', 'noopener,noreferrer');
                 }
               };
-              
+
               return (
                 <Box
                   key={entity.id || idx}
@@ -277,7 +277,7 @@ export const OCTIImportResultsView: React.FC<ImportResultsViewProps> = ({
                         e.stopPropagation();
                         handleOpenEntity();
                       }}
-                      sx={{ 
+                      sx={{
                         color: 'text.secondary',
                         '&:hover': { color: 'primary.main' },
                       }}

--- a/src/shared/types/scan.ts
+++ b/src/shared/types/scan.ts
@@ -72,13 +72,22 @@ export interface ScanResultEntity {
 // ============================================================================
 
 /**
+ * A single entity that failed to be created during an import or container operation.
+ */
+export interface FailedEntityImport {
+  type: string;
+  value: string;
+  error?: string;
+}
+
+/**
  * Results from bulk entity import operation
  */
 export interface ImportResults {
   success: boolean;
   total: number;
   created: Array<{ id: string; type: string; value: string }>;
-  failed: Array<{ type: string; value: string; error?: string }>;
+  failed: FailedEntityImport[];
   platformName: string;
   platformUrl: string;
 }

--- a/tests/unit/container-handlers.test.ts
+++ b/tests/unit/container-handlers.test.ts
@@ -116,6 +116,37 @@ describe('handleCreateContainer', () => {
     }));
   });
 
+  it('should use stable indices for relationships when a preceding entity creation fails', async () => {
+    // entity at index 0 fails, entity at index 1 succeeds.
+    // a relationship between index 1 (entitiesToCreate) and index 0 (existing entity)
+    // must still resolve correctly — index 0 maps to the pre-existing entity.
+    const client = makeClient({
+      createEntity: vi.fn()
+        .mockRejectedValueOnce(new Error('API error'))        // entitiesToCreate[0] fails
+        .mockResolvedValueOnce({ id: 'entity-2', entity_type: 'Domain-Name' }), // entitiesToCreate[1] succeeds
+    });
+    const clients = new Map([['platform-1', client as any]]);
+    const payload = makePayload({
+      entities: ['existing-1'],
+      entitiesToCreate: [
+        { type: 'IPv4-Addr', value: '1.2.3.4' },   // index 1 in combined array (after existing-1)
+        { type: 'Domain-Name', value: 'evil.com' }, // index 2 in combined array
+      ],
+      relationshipsToCreate: [
+        // relationship between existing-1 (index 0) and Domain-Name (index 2)
+        { fromEntityIndex: 0, toEntityIndex: 2, relationship_type: 'related-to' },
+      ],
+    });
+
+    await handleCreateContainer(payload, mockSendResponse, clients);
+
+    expect(client.createStixCoreRelationship).toHaveBeenCalledWith(expect.objectContaining({
+      fromId: 'existing-1',
+      toId: 'entity-2',
+    }));
+    expect(mockSendResponse).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+  });
+
   it('should report all entities as failed but still create the container', async () => {
     const client = makeClient({
       createEntity: vi.fn().mockRejectedValue(new Error('API error')),

--- a/tests/unit/container-handlers.test.ts
+++ b/tests/unit/container-handlers.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Tests for Container Message Handler
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { handleCreateContainer } from '../../src/background/handlers/container-handlers';
+
+vi.mock('../../src/shared/detection/patterns', () => ({
+  refangIndicator: vi.fn((v: string) => v),
+}));
+
+vi.mock('../../src/shared/utils/logger', () => ({
+  loggers: {
+    background: { info: vi.fn(), debug: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  },
+}));
+
+const makeClient = (overrides = {}) => ({
+  createEntity: vi.fn().mockResolvedValue({ id: 'entity-1', entity_type: 'Malware' }),
+  createStixCoreRelationship: vi.fn().mockResolvedValue({ id: 'rel-1' }),
+  createExternalReference: vi.fn().mockResolvedValue({ id: 'extref-1' }),
+  addExternalReferenceToEntity: vi.fn().mockResolvedValue(undefined),
+  uploadFileToEntity: vi.fn().mockResolvedValue(undefined),
+  createContainer: vi.fn().mockResolvedValue({ id: 'container-1', entity_type: 'Report', name: 'Test Report' }),
+  ...overrides,
+});
+
+const makePayload = (overrides = {}): any => ({
+  type: 'Report',
+  name: 'Test Report',
+  description: '',
+  labels: [],
+  markings: [],
+  entities: [],
+  entitiesToCreate: [],
+  platformId: 'platform-1',
+  ...overrides,
+});
+
+describe('handleCreateContainer', () => {
+  const mockSendResponse = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return error when no clients configured', async () => {
+    await handleCreateContainer(makePayload(), mockSendResponse, new Map());
+    expect(mockSendResponse).toHaveBeenCalledWith({ success: false, error: 'Not configured' });
+  });
+
+  it('should create container successfully with no entities to create', async () => {
+    const client = makeClient();
+    const clients = new Map([['platform-1', client as any]]);
+
+    await handleCreateContainer(makePayload(), mockSendResponse, clients);
+
+    expect(client.createContainer).toHaveBeenCalledOnce();
+    expect(mockSendResponse).toHaveBeenCalledWith(expect.objectContaining({
+      success: true,
+      data: expect.objectContaining({ id: 'container-1', failedEntities: undefined }),
+    }));
+  });
+
+  it('should create all entities and attach them to the container', async () => {
+    const client = makeClient({
+      createEntity: vi.fn()
+        .mockResolvedValueOnce({ id: 'entity-1', entity_type: 'IPv4-Addr' })
+        .mockResolvedValueOnce({ id: 'entity-2', entity_type: 'Domain-Name' }),
+    });
+    const clients = new Map([['platform-1', client as any]]);
+    const payload = makePayload({
+      entitiesToCreate: [
+        { type: 'IPv4-Addr', value: '1.2.3.4' },
+        { type: 'Domain-Name', value: 'evil.com' },
+      ],
+    });
+
+    await handleCreateContainer(payload, mockSendResponse, clients);
+
+    expect(client.createEntity).toHaveBeenCalledTimes(2);
+    expect(client.createContainer).toHaveBeenCalledWith(expect.objectContaining({
+      objects: expect.arrayContaining(['entity-1', 'entity-2']),
+    }));
+    expect(mockSendResponse).toHaveBeenCalledWith(expect.objectContaining({
+      success: true,
+      data: expect.objectContaining({ failedEntities: undefined }),
+    }));
+  });
+
+  it('should continue and report failed entities when some entity creation fails', async () => {
+    const client = makeClient({
+      createEntity: vi.fn()
+        .mockResolvedValueOnce({ id: 'entity-1', entity_type: 'IPv4-Addr' })
+        .mockRejectedValueOnce(new Error('Forbidden by marking')),
+    });
+    const clients = new Map([['platform-1', client as any]]);
+    const payload = makePayload({
+      entitiesToCreate: [
+        { type: 'IPv4-Addr', value: '1.2.3.4' },
+        { type: 'Domain-Name', value: 'evil.com' },
+      ],
+    });
+
+    await handleCreateContainer(payload, mockSendResponse, clients);
+
+    // Container still created with the one that succeeded
+    expect(client.createContainer).toHaveBeenCalledWith(expect.objectContaining({
+      objects: expect.arrayContaining(['entity-1']),
+    }));
+    expect(mockSendResponse).toHaveBeenCalledWith(expect.objectContaining({
+      success: true,
+      data: expect.objectContaining({
+        failedEntities: [{ type: 'Domain-Name', value: 'evil.com', error: 'Forbidden by marking' }],
+      }),
+    }));
+  });
+
+  it('should report all entities as failed but still create the container', async () => {
+    const client = makeClient({
+      createEntity: vi.fn().mockRejectedValue(new Error('API error')),
+    });
+    const clients = new Map([['platform-1', client as any]]);
+    const payload = makePayload({
+      entitiesToCreate: [
+        { type: 'IPv4-Addr', value: '1.2.3.4' },
+        { type: 'Domain-Name', value: 'evil.com' },
+      ],
+    });
+
+    await handleCreateContainer(payload, mockSendResponse, clients);
+
+    expect(client.createContainer).toHaveBeenCalledOnce();
+    expect(mockSendResponse).toHaveBeenCalledWith(expect.objectContaining({
+      success: true,
+      data: expect.objectContaining({
+        failedEntities: [
+          { type: 'IPv4-Addr', value: '1.2.3.4', error: 'API error' },
+          { type: 'Domain-Name', value: 'evil.com', error: 'API error' },
+        ],
+      }),
+    }));
+  });
+
+  it('should return error when container creation itself fails', async () => {
+    const client = makeClient({
+      createContainer: vi.fn().mockRejectedValue(new Error('Unauthorized')),
+    });
+    const clients = new Map([['platform-1', client as any]]);
+
+    await handleCreateContainer(makePayload(), mockSendResponse, clients);
+
+    expect(mockSendResponse).toHaveBeenCalledWith({ success: false, error: 'Unauthorized' });
+  });
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request! We as a community driven project
depend on support and contributions like this.

Title convention (Conventional Commits + GitHub reference):
  type(scope?): description (#issue)
Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert.
See .github/LABELS.md for the full taxonomy.
-->

### Proposed changes

* Show observable creation failure to user on the container creation report step

### Related issues

<!-- This PR must be linked to an issue. Use a closing keyword. -->
* Closes #175 

### How to test this PR

- Configure the extension to work with an OCTI user with low permission access
- Scan a page, select some observables and create them in the platform within a container
- The container creation is successful and you are redirected to the success page but you see the list of entities that haven't been created and the toast inform you of the partial success
- Try with another user with large permissions
- The container creation is successful and the success page is unchanged

### Checklist

- [x] The PR title follows the Conventional Commits convention `type(scope?): description (#issue)`
- [x] I signed my commits
- [x] This PR is linked to an issue
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I added/updated the relevant documentation
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you considered. -->
