### PR TITLE
fix(draft): draft observables creation respect draft mode setting (#181)

### DIFF
--- a/src/background/handlers/container-handlers.ts
+++ b/src/background/handlers/container-handlers.ts
@@ -51,11 +51,20 @@ export async function handleCreateContainer(
       | { status: 'created'; id: string }
       | { status: 'failed'; type: string; value: string; error: string };
 
+    // Pre-create draft workspace so ALL entities, relationships and external references
+    // are seeded into the draft context before the container itself is created.
+    let draftId: string | undefined;
+    if (payload.createAsDraft) {
+      const draftWorkspace = await client.createDraftWorkspace(`Draft - ${payload.name}`);
+      draftId = draftWorkspace.id;
+      log.debug(`Pre-created draft workspace: ${draftId}`);
+    }
+
     const creationResults: CreationResult[] = await Promise.all(
       (payload.entitiesToCreate || []).map(async (e): Promise<CreationResult> => {
         try {
           const cleanValue = refangIndicator(e.value);
-          const created = await client.createEntity({ type: e.type, value: cleanValue, name: cleanValue });
+          const created = await client.createEntity({ type: e.type, value: cleanValue, name: cleanValue }, draftId);
           log.debug(`Created entity: ${e.type} = ${cleanValue} -> ${created.id}`);
           return { status: 'created', id: created.id };
         } catch (err) {
@@ -101,7 +110,7 @@ export async function handleCreateContainer(
             toId,
             relationship_type: rel.relationship_type,
             description: rel.description,
-          });
+          }, draftId);
 
           if (relationship?.id) {
             createdRelationships.push({
@@ -130,7 +139,7 @@ export async function handleCreateContainer(
           source_name: 'PDF Document',
           description: payload.pageTitle || 'Source PDF document',
           external_id: payload.pdfFileName,
-        });
+        }, draftId);
         externalReferenceId = extRef.id;
         log.debug(`Created external reference with external_id: ${payload.pdfFileName}`);
       } catch (extRefError) {
@@ -144,7 +153,7 @@ export async function handleCreateContainer(
           source_name: 'Web Article',
           description: payload.pageTitle || 'Source article',
           url: payload.pageUrl,
-        });
+        }, draftId);
         externalReferenceId = extRef.id;
         log.debug(`Created external reference: ${externalReferenceId}`);
       } catch (extRefError) {
@@ -176,8 +185,9 @@ export async function handleCreateContainer(
       priority: payload.priority,
       response_types: payload.response_types,
       createdBy: payload.createdBy,
-      // Draft mode
+      // Draft mode: pass pre-created draftId so createContainer skips internal workspace creation
       createAsDraft: payload.createAsDraft,
+      draftId,
       // Update mode: pass original dates to avoid creating duplicates
       // For Reports, use 'published'; for other containers, use 'created'
       published: payload.published,
@@ -187,7 +197,7 @@ export async function handleCreateContainer(
     // Step 4: Attach external reference to the container
     if (externalReferenceId && container.id) {
       try {
-        await client.addExternalReferenceToEntity(container.id, externalReferenceId);
+        await client.addExternalReferenceToEntity(container.id, externalReferenceId, draftId);
         log.debug('Attached external reference to container');
       } catch (attachError) {
         log.warn('Failed to attach external reference to container:', attachError);

--- a/src/shared/api/opencti-client.ts
+++ b/src/shared/api/opencti-client.ts
@@ -468,7 +468,7 @@ export class OpenCTIClient {
     createIndicator?: boolean;
     objectMarking?: string[];
     objectLabel?: string[];
-  }): Promise<OCTIStixCyberObservable> {
+  }, draftId?: string): Promise<OCTIStixCyberObservable> {
     // OpenCTI uses the type as-is (with hyphens) for the 'type' field
     const gqlType = toGraphQLInputType(input.type);
     const observableInput = buildObservableInput(input.type, input.value, input.hashType);
@@ -485,7 +485,8 @@ export class OpenCTIClient {
 
     const data = await this.query<{ stixCyberObservableAdd: OCTIStixCyberObservable }>(
       buildCreateObservableMutation(gqlType),
-      variables
+      variables,
+      draftId,
     );
     return data.stixCyberObservableAdd;
   }
@@ -494,74 +495,74 @@ export class OpenCTIClient {
   // SDO Creation Methods
   // ==========================================================================
 
-  async createIntrusionSet(input: { name: string; description?: string; objectMarking?: string[]; objectLabel?: string[] }) {
-    const data = await this.query<{ intrusionSetAdd: { id: string; standard_id: string; entity_type: string; name: string; aliases?: string[] } }>(CREATE_INTRUSION_SET_MUTATION, { input });
+  async createIntrusionSet(input: { name: string; description?: string; objectMarking?: string[]; objectLabel?: string[] }, draftId?: string) {
+    const data = await this.query<{ intrusionSetAdd: { id: string; standard_id: string; entity_type: string; name: string; aliases?: string[] } }>(CREATE_INTRUSION_SET_MUTATION, { input }, draftId);
     return data.intrusionSetAdd;
   }
 
-  async createThreatActorGroup(input: { name: string; description?: string; threat_actor_types?: string[]; objectMarking?: string[]; objectLabel?: string[] }) {
+  async createThreatActorGroup(input: { name: string; description?: string; threat_actor_types?: string[]; objectMarking?: string[]; objectLabel?: string[] }, draftId?: string) {
     const data = await this.query<{ threatActorGroupAdd: { id: string; standard_id: string; entity_type: string; name: string; aliases?: string[] } }>(CREATE_THREAT_ACTOR_GROUP_MUTATION, {
       input: { ...input, threat_actor_types: input.threat_actor_types || ['unknown'] },
-    });
+    }, draftId);
     return data.threatActorGroupAdd;
   }
 
-  async createThreatActorIndividual(input: { name: string; description?: string; threat_actor_types?: string[]; objectMarking?: string[]; objectLabel?: string[] }) {
+  async createThreatActorIndividual(input: { name: string; description?: string; threat_actor_types?: string[]; objectMarking?: string[]; objectLabel?: string[] }, draftId?: string) {
     const data = await this.query<{ threatActorIndividualAdd: { id: string; standard_id: string; entity_type: string; name: string; aliases?: string[] } }>(CREATE_THREAT_ACTOR_INDIVIDUAL_MUTATION, {
       input: { ...input, threat_actor_types: input.threat_actor_types || ['unknown'] },
-    });
+    }, draftId);
     return data.threatActorIndividualAdd;
   }
 
-  async createMalware(input: { name: string; description?: string; malware_types?: string[]; is_family?: boolean; objectMarking?: string[]; objectLabel?: string[] }) {
+  async createMalware(input: { name: string; description?: string; malware_types?: string[]; is_family?: boolean; objectMarking?: string[]; objectLabel?: string[] }, draftId?: string) {
     const data = await this.query<{ malwareAdd: { id: string; standard_id: string; entity_type: string; name: string; aliases?: string[] } }>(CREATE_MALWARE_MUTATION, {
       input: { ...input, malware_types: input.malware_types || ['unknown'], is_family: input.is_family ?? true },
-    });
+    }, draftId);
     return data.malwareAdd;
   }
 
-  async createTool(input: { name: string; description?: string; objectMarking?: string[]; objectLabel?: string[] }) {
-    const data = await this.query<{ toolAdd: { id: string; standard_id: string; entity_type: string; name: string; aliases?: string[] } }>(CREATE_TOOL_MUTATION, { input });
+  async createTool(input: { name: string; description?: string; objectMarking?: string[]; objectLabel?: string[] }, draftId?: string) {
+    const data = await this.query<{ toolAdd: { id: string; standard_id: string; entity_type: string; name: string; aliases?: string[] } }>(CREATE_TOOL_MUTATION, { input }, draftId);
     return data.toolAdd;
   }
 
-  async createCampaign(input: { name: string; description?: string; objectMarking?: string[]; objectLabel?: string[] }) {
-    const data = await this.query<{ campaignAdd: { id: string; standard_id: string; entity_type: string; name: string; aliases?: string[] } }>(CREATE_CAMPAIGN_MUTATION, { input });
+  async createCampaign(input: { name: string; description?: string; objectMarking?: string[]; objectLabel?: string[] }, draftId?: string) {
+    const data = await this.query<{ campaignAdd: { id: string; standard_id: string; entity_type: string; name: string; aliases?: string[] } }>(CREATE_CAMPAIGN_MUTATION, { input }, draftId);
     return data.campaignAdd;
   }
 
-  async createVulnerability(input: { name: string; description?: string; objectMarking?: string[]; objectLabel?: string[] }) {
-    const data = await this.query<{ vulnerabilityAdd: { id: string; standard_id: string; entity_type: string; name: string } }>(CREATE_VULNERABILITY_MUTATION, { input });
+  async createVulnerability(input: { name: string; description?: string; objectMarking?: string[]; objectLabel?: string[] }, draftId?: string) {
+    const data = await this.query<{ vulnerabilityAdd: { id: string; standard_id: string; entity_type: string; name: string } }>(CREATE_VULNERABILITY_MUTATION, { input }, draftId);
     return data.vulnerabilityAdd;
   }
 
-  async createAttackPattern(input: { name: string; description?: string; x_mitre_id?: string; objectMarking?: string[]; objectLabel?: string[] }) {
-    const data = await this.query<{ attackPatternAdd: { id: string; standard_id: string; entity_type: string; name: string; x_mitre_id?: string; aliases?: string[] } }>(CREATE_ATTACK_PATTERN_MUTATION, { input });
+  async createAttackPattern(input: { name: string; description?: string; x_mitre_id?: string; objectMarking?: string[]; objectLabel?: string[] }, draftId?: string) {
+    const data = await this.query<{ attackPatternAdd: { id: string; standard_id: string; entity_type: string; name: string; x_mitre_id?: string; aliases?: string[] } }>(CREATE_ATTACK_PATTERN_MUTATION, { input }, draftId);
     return data.attackPatternAdd;
   }
 
-  async createCountry(input: { name: string; description?: string; objectMarking?: string[]; objectLabel?: string[] }) {
-    const data = await this.query<{ countryAdd: { id: string; standard_id: string; entity_type: string; name: string } }>(CREATE_COUNTRY_MUTATION, { input });
+  async createCountry(input: { name: string; description?: string; objectMarking?: string[]; objectLabel?: string[] }, draftId?: string) {
+    const data = await this.query<{ countryAdd: { id: string; standard_id: string; entity_type: string; name: string } }>(CREATE_COUNTRY_MUTATION, { input }, draftId);
     return data.countryAdd;
   }
 
-  async createSector(input: { name: string; description?: string; objectMarking?: string[]; objectLabel?: string[] }) {
-    const data = await this.query<{ sectorAdd: { id: string; standard_id: string; entity_type: string; name: string } }>(CREATE_SECTOR_MUTATION, { input });
+  async createSector(input: { name: string; description?: string; objectMarking?: string[]; objectLabel?: string[] }, draftId?: string) {
+    const data = await this.query<{ sectorAdd: { id: string; standard_id: string; entity_type: string; name: string } }>(CREATE_SECTOR_MUTATION, { input }, draftId);
     return data.sectorAdd;
   }
 
-  async createNarrative(input: { name: string; description?: string; objectMarking?: string[]; objectLabel?: string[] }) {
-    const data = await this.query<{ narrativeAdd: { id: string; standard_id: string; entity_type: string; name: string; aliases?: string[] } }>(CREATE_NARRATIVE_MUTATION, { input });
+  async createNarrative(input: { name: string; description?: string; objectMarking?: string[]; objectLabel?: string[] }, draftId?: string) {
+    const data = await this.query<{ narrativeAdd: { id: string; standard_id: string; entity_type: string; name: string; aliases?: string[] } }>(CREATE_NARRATIVE_MUTATION, { input }, draftId);
     return data.narrativeAdd;
   }
 
-  async createChannel(input: { name: string; description?: string; channel_types?: string[]; objectMarking?: string[]; objectLabel?: string[] }) {
-    const data = await this.query<{ channelAdd: { id: string; standard_id: string; entity_type: string; name: string; aliases?: string[] } }>(CREATE_CHANNEL_MUTATION, { input });
+  async createChannel(input: { name: string; description?: string; channel_types?: string[]; objectMarking?: string[]; objectLabel?: string[] }, draftId?: string) {
+    const data = await this.query<{ channelAdd: { id: string; standard_id: string; entity_type: string; name: string; aliases?: string[] } }>(CREATE_CHANNEL_MUTATION, { input }, draftId);
     return data.channelAdd;
   }
 
-  async createSystem(input: { name: string; description?: string; objectMarking?: string[]; objectLabel?: string[] }) {
-    const data = await this.query<{ systemAdd: { id: string; standard_id: string; entity_type: string; name: string; x_opencti_aliases?: string[] } }>(CREATE_SYSTEM_MUTATION, { input });
+  async createSystem(input: { name: string; description?: string; objectMarking?: string[]; objectLabel?: string[] }, draftId?: string) {
+    const data = await this.query<{ systemAdd: { id: string; standard_id: string; entity_type: string; name: string; x_opencti_aliases?: string[] } }>(CREATE_SYSTEM_MUTATION, { input }, draftId);
     return data.systemAdd;
   }
 
@@ -573,7 +574,7 @@ export class OpenCTIClient {
     x_mitre_id?: string;
     objectMarking?: string[];
     objectLabel?: string[];
-  }): Promise<{ id: string; standard_id: string; entity_type: string; name?: string; observable_value?: string; aliases?: string[]; x_mitre_id?: string }> {
+  }, draftId?: string): Promise<{ id: string; standard_id: string; entity_type: string; name?: string; observable_value?: string; aliases?: string[]; x_mitre_id?: string }> {
     const normalizedType = input.type.toLowerCase().replace(/[_\s]/g, '-');
     const entityName = input.name || input.value || 'Unknown';
     
@@ -588,19 +589,19 @@ export class OpenCTIClient {
     }
 
     const sdoTypes: Record<string, () => Promise<{ id: string; standard_id: string; entity_type: string; name: string; aliases?: string[]; x_opencti_aliases?: string[]; x_mitre_id?: string }>> = {
-      'intrusion-set': () => this.createIntrusionSet({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }),
-      'threat-actor-group': () => this.createThreatActorGroup({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }),
-      'threat-actor-individual': () => this.createThreatActorIndividual({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }),
-      'malware': () => this.createMalware({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }),
-      'tool': () => this.createTool({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }),
-      'campaign': () => this.createCampaign({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }),
-      'vulnerability': () => this.createVulnerability({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }),
-      'attack-pattern': () => this.createAttackPattern({ name: entityName, description: input.description, x_mitre_id: mitreId, objectMarking: input.objectMarking, objectLabel: input.objectLabel }),
-      'country': () => this.createCountry({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }),
-      'sector': () => this.createSector({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }),
-      'narrative': () => this.createNarrative({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }),
-      'channel': () => this.createChannel({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }),
-      'system': () => this.createSystem({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }),
+      'intrusion-set': () => this.createIntrusionSet({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }, draftId),
+      'threat-actor-group': () => this.createThreatActorGroup({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }, draftId),
+      'threat-actor-individual': () => this.createThreatActorIndividual({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }, draftId),
+      'malware': () => this.createMalware({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }, draftId),
+      'tool': () => this.createTool({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }, draftId),
+      'campaign': () => this.createCampaign({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }, draftId),
+      'vulnerability': () => this.createVulnerability({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }, draftId),
+      'attack-pattern': () => this.createAttackPattern({ name: entityName, description: input.description, x_mitre_id: mitreId, objectMarking: input.objectMarking, objectLabel: input.objectLabel }, draftId),
+      'country': () => this.createCountry({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }, draftId),
+      'sector': () => this.createSector({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }, draftId),
+      'narrative': () => this.createNarrative({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }, draftId),
+      'channel': () => this.createChannel({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }, draftId),
+      'system': () => this.createSystem({ name: entityName, description: input.description, objectMarking: input.objectMarking, objectLabel: input.objectLabel }, draftId),
     };
 
     if (sdoTypes[normalizedType]) {
@@ -618,7 +619,7 @@ export class OpenCTIClient {
       description: input.description,
       objectMarking: input.objectMarking,
       objectLabel: input.objectLabel,
-    });
+    }, draftId);
 
     return {
       id: observable.id,
@@ -632,13 +633,13 @@ export class OpenCTIClient {
   // External Reference Operations
   // ==========================================================================
 
-  async createExternalReference(input: { source_name: string; url?: string; external_id?: string; description?: string }): Promise<{ id: string; standard_id: string; url?: string }> {
-    const data = await this.query<{ externalReferenceAdd: { id: string; standard_id: string; url?: string } }>(CREATE_EXTERNAL_REFERENCE_MUTATION, { input });
+  async createExternalReference(input: { source_name: string; url?: string; external_id?: string; description?: string }, draftId?: string): Promise<{ id: string; standard_id: string; url?: string }> {
+    const data = await this.query<{ externalReferenceAdd: { id: string; standard_id: string; url?: string } }>(CREATE_EXTERNAL_REFERENCE_MUTATION, { input }, draftId);
     return data.externalReferenceAdd;
   }
 
-  async addExternalReferenceToEntity(entityId: string, externalReferenceId: string): Promise<void> {
-    await this.query(ADD_EXTERNAL_REFERENCE_TO_ENTITY_MUTATION, { id: entityId, input: { toId: externalReferenceId, relationship_type: 'external-reference' } });
+  async addExternalReferenceToEntity(entityId: string, externalReferenceId: string, draftId?: string): Promise<void> {
+    await this.query(ADD_EXTERNAL_REFERENCE_TO_ENTITY_MUTATION, { id: entityId, input: { toId: externalReferenceId, relationship_type: 'external-reference' } }, draftId);
   }
 
   async findExternalReferencesByUrl(url: string): Promise<Array<{ id: string; url: string; source_name: string }>> {
@@ -667,8 +668,14 @@ export class OpenCTIClient {
   async createContainer(input: OCTIContainerCreateInput): Promise<OCTIStixDomainObject & { draftId?: string }> {
     let draftId: string | undefined;
     if (input.createAsDraft) {
-      const draftWorkspace = await this.createDraftWorkspace(`Draft - ${input.name}`);
-      draftId = draftWorkspace.id;
+      // Use pre-created draft workspace if provided (e.g. from container-handlers which
+      // must create the workspace first so entities can be seeded into the same draft).
+      if (input.draftId) {
+        draftId = input.draftId;
+      } else {
+        const draftWorkspace = await this.createDraftWorkspace(`Draft - ${input.name}`);
+        draftId = draftWorkspace.id;
+      }
     }
 
     const containerInput: Record<string, unknown> = {
@@ -861,8 +868,8 @@ export class OpenCTIClient {
     }
   }
 
-  async createStixCoreRelationship(input: { fromId: string; toId: string; relationship_type: string; description?: string; confidence?: number; objectMarking?: string[] }): Promise<{ id: string; standard_id: string }> {
-    const data = await this.query<{ stixCoreRelationshipAdd: { id: string; standard_id: string } }>(CREATE_RELATIONSHIP_MUTATION, { input });
+  async createStixCoreRelationship(input: { fromId: string; toId: string; relationship_type: string; description?: string; confidence?: number; objectMarking?: string[] }, draftId?: string): Promise<{ id: string; standard_id: string }> {
+    const data = await this.query<{ stixCoreRelationshipAdd: { id: string; standard_id: string } }>(CREATE_RELATIONSHIP_MUTATION, { input }, draftId);
     return data.stixCoreRelationshipAdd;
   }
 

--- a/src/shared/types/opencti.ts
+++ b/src/shared/types/opencti.ts
@@ -216,6 +216,7 @@ export interface OCTIContainerCreateInput {
   createdBy?: string;
   externalReferences?: OCTIExternalReferenceInput[];
   createAsDraft?: boolean;
+  draftId?: string;
 }
 
 export interface OCTIExternalReferenceInput {

--- a/tests/unit/container-handlers.test.ts
+++ b/tests/unit/container-handlers.test.ts
@@ -16,6 +16,7 @@ vi.mock('../../src/shared/utils/logger', () => ({
 }));
 
 const makeClient = (overrides = {}) => ({
+  createDraftWorkspace: vi.fn().mockResolvedValue({ id: 'draft-ws-1', name: 'Draft - Test Report' }),
   createEntity: vi.fn().mockResolvedValue({ id: 'entity-1', entity_type: 'Malware' }),
   createStixCoreRelationship: vi.fn().mockResolvedValue({ id: 'rel-1' }),
   createExternalReference: vi.fn().mockResolvedValue({ id: 'extref-1' }),
@@ -143,7 +144,7 @@ describe('handleCreateContainer', () => {
     expect(client.createStixCoreRelationship).toHaveBeenCalledWith(expect.objectContaining({
       fromId: 'existing-1',
       toId: 'entity-2',
-    }));
+    }), undefined);
     expect(mockSendResponse).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
   });
 
@@ -182,5 +183,53 @@ describe('handleCreateContainer', () => {
     await handleCreateContainer(makePayload(), mockSendResponse, clients);
 
     expect(mockSendResponse).toHaveBeenCalledWith({ success: false, error: 'Unauthorized' });
+  });
+
+  describe('draft mode', () => {
+    it('should pre-create draft workspace before entities and thread draftId to all creation calls', async () => {
+      const client = makeClient({
+        createEntity: vi.fn().mockResolvedValue({ id: 'entity-1', entity_type: 'IPv4-Addr' }),
+      });
+      const clients = new Map([['platform-1', client as any]]);
+      const payload = makePayload({
+        createAsDraft: true,
+        entitiesToCreate: [{ type: 'IPv4-Addr', value: '1.2.3.4' }],
+        pageUrl: 'https://example.com',
+        pageTitle: 'Article',
+        relationshipsToCreate: [
+          { fromEntityIndex: 0, toEntityIndex: 0, relationship_type: 'related-to' },
+        ],
+      });
+
+      // Capture call order
+      const callOrder: string[] = [];
+      client.createDraftWorkspace.mockImplementation(async () => { callOrder.push('createDraftWorkspace'); return { id: 'draft-ws-1' }; });
+      client.createEntity.mockImplementation(async () => { callOrder.push('createEntity'); return { id: 'entity-1', entity_type: 'IPv4-Addr' }; });
+      client.createExternalReference.mockImplementation(async () => { callOrder.push('createExternalReference'); return { id: 'extref-1' }; });
+
+      await handleCreateContainer(payload, mockSendResponse, clients);
+
+      // Workspace must be first
+      expect(callOrder[0]).toBe('createDraftWorkspace');
+
+      // draftId threaded into every subsequent call
+      expect(client.createEntity).toHaveBeenCalledWith(expect.anything(), 'draft-ws-1');
+      expect(client.createExternalReference).toHaveBeenCalledWith(expect.anything(), 'draft-ws-1');
+      expect(client.createContainer).toHaveBeenCalledWith(expect.objectContaining({
+        createAsDraft: true,
+        draftId: 'draft-ws-1',
+      }));
+      expect(mockSendResponse).toHaveBeenCalledWith(expect.objectContaining({ success: true }));
+    });
+
+    it('should NOT call createDraftWorkspace when createAsDraft is false', async () => {
+      const client = makeClient();
+      const clients = new Map([['platform-1', client as any]]);
+
+      await handleCreateContainer(makePayload({ createAsDraft: false }), mockSendResponse, clients);
+
+      expect(client.createDraftWorkspace).not.toHaveBeenCalled();
+      expect(client.createContainer).toHaveBeenCalledWith(expect.objectContaining({ draftId: undefined }));
+    });
   });
 });

--- a/tests/unit/opencti-client.test.ts
+++ b/tests/unit/opencti-client.test.ts
@@ -1000,6 +1000,35 @@ describe('OpenCTIClient', () => {
       expect(client1).not.toBe(client2);
     });
   });
+
+  // ============================================================================
+  // Draft context propagation
+  // ============================================================================
+
+  describe('draft context propagation', () => {
+    it('should use pre-existing draftId in createContainer: skip workspace creation and send opencti-draft-id header', async () => {
+      // Only ONE fetch expected — workspace already created externally, no createDraftWorkspace call
+      mockFetch.mockResolvedValueOnce(createMockResponse({
+        reportAdd: { id: 'report-1', entity_type: 'Report', name: 'Test' },
+      }));
+
+      const result = await client.createContainer({
+        type: 'Report',
+        name: 'Test',
+        createAsDraft: true,
+        draftId: 'draft-pre-created',
+      });
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          headers: expect.objectContaining({ 'opencti-draft-id': 'draft-pre-created' }),
+        })
+      );
+      expect(result.draftId).toBe('draft-pre-created');
+    });
+  });
 });
 
 // ============================================================================


### PR DESCRIPTION
<!--
Thank you very much for your pull request! We as a community driven project
depend on support and contributions like this.

Title convention (Conventional Commits + GitHub reference):
  type(scope?): description (#issue)
Types: feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert.
See .github/LABELS.md for the full taxonomy.
-->

### Proposed changes

* When user wants to create a container in draft mode, create the draft before any other creation and then pass the draft id for all entity creation

### Related issues

<!-- This PR must be linked to an issue. Use a closing keyword. -->
* Closes #181 

### How to test this PR

<!-- Please give example or instructions for the reviewer to test this PR. -->

### Checklist

- [x] The PR title follows the Conventional Commits convention `type(scope?): description (#issue)`
- [x] I signed my commits
- [x] This PR is linked to an issue
- [x] I consider the submitted work as finished
- [x] I tested the code for its functionality
- [x] I added/updated the relevant documentation
- [x] Where necessary, I refactored code to improve the overall quality

### Further comments

<!-- If this is a relatively large or complex change, kick off the discussion by
explaining why you chose the solution you did and what alternatives you considered. -->
